### PR TITLE
Disable agner support when KERL_DISABLE_AGNER is not empty

### DIFF
--- a/kerl
+++ b/kerl
@@ -137,7 +137,7 @@ R12B-2 R12B-3 R12B-4 R12B-5 R13A R13B R13B01 R13B02 R13B03 R13B04"
 
 agner_support()
 {
-    if [ -z "$KERL_DISABLE_AGNER" ]; then
+    if [ -n "$KERL_DISABLE_AGNER" ]; then
         return 1;
     fi
 


### PR DESCRIPTION
Operator `-n` should be used instead of `-z` because it makes no sense to
disable Agner support only when KERL_DISABLE_AGNER is empty.
