### PR TITLE
XCode 4.2 compatibility

### DIFF
--- a/kerl
+++ b/kerl
@@ -292,7 +292,7 @@ do_build()
         Darwin)
             if [ `gcc --version | grep llvm | wc -l` = "1" ]; then
                 if lion_support $1; then
-                    true
+                    KERL_CONFIGURE_OPTIONS="CFLAGS=-O0 $KERL_CONFIGURE_OPTIONS"
                 else
                     if [ -x "`which gcc-4.2`" ]; then
                         KERL_CONFIGURE_OPTIONS="CC=gcc-4.2 $KERL_CONFIGURE_OPTIONS"


### PR DESCRIPTION
With xcode 4.2 gm (released October 12), apple removed /usr/bin/gcc-4.2, forcing use of /usr/bin/llvm-gcc-4.2 to compile erlang.

Without this change, a new machine from apple will fail the configure phase - (not finding the C compiler).

This change does two things:

1)  Fix the which gcc-4.2 conditional bash statement.  This was alway evaluating to "true".  Just needed quotes.
2)  Added llvm-gcc-4.2 if gcc-4.2 can not be found.

Please consider for merge.

I have tested this (using kerl build only) under r14b04, and r13b04.

-- Randy
