### PR TITLE
Basic OpenBSD support.

### DIFF
--- a/kerl
+++ b/kerl
@@ -65,7 +65,7 @@ fi
 
 KERL_SYSTEM=`uname -s`
 case "$KERL_SYSTEM" in
-    Darwin)
+    Darwin|OpenBSD)
         MD5SUM="openssl md5"
         MD5SUM_FIELD=2
         SED_OPT=-E


### PR DESCRIPTION
OpenBSD has no md5sum utility. So we use OpenSSL instead of it.
