### PR TITLE
Make kerl work with OTP < R15B on newer Solarii

### DIFF
--- a/kerl
+++ b/kerl
@@ -288,6 +288,20 @@ do_git_build()
 
 do_build()
 {
+    assert_valid_release $1
+    assert_build_name_unused $2
+
+    FILENAME=otp_src_$1.tar.gz
+    download "$FILENAME"
+    mkdir -p "$KERL_BUILD_DIR/$2"
+    if [ ! -d "$KERL_BUILD_DIR/$2/otp_src_$1" ]; then
+        echo "Extracting source code"
+        cd "$KERL_BUILD_DIR/$2" && tar xfz "$KERL_DOWNLOAD_DIR/$FILENAME"
+    fi
+    echo "Building Erlang/OTP $1 ($2), please wait..."
+    ERL_TOP="$KERL_BUILD_DIR/$2/otp_src_$1"
+    cd "$ERL_TOP"
+
     case "$KERL_SYSTEM" in
         Darwin)
             if [ `gcc --version | grep llvm | wc -l` = "1" ]; then
@@ -302,23 +316,38 @@ do_build()
                 fi
             fi
         ;;
+        SunOS)
+            if [ `get_release $1` -lt 15 ]; then
+                echo "Release $1 is broken on $KERL_SYSTEM.  Patching..."
+                patch -p1 <<EOF
+diff -urN otp-a/erts/emulator/drivers/common/inet_drv.c otp-b/erts/emulator/drivers/common/inet_drv.c
+--- otp-a/erts/emulator/drivers/common/inet_drv.c
++++ otp-b/erts/emulator/drivers/common/inet_drv.c
+@@ -4166,16 +4166,7 @@
+ 	    break;
+ 
+ 	case INET_IFOPT_HWADDR: {
+-#ifdef SIOCGIFHWADDR
+-	    if (ioctl(desc->s, SIOCGIFHWADDR, (char *)&ifreq) < 0)
+-		break;
+-	    buf_check(sptr, s_end, 1+2+IFHWADDRLEN);
+-	    *sptr++ = INET_IFOPT_HWADDR;
+-	    put_int16(IFHWADDRLEN, sptr); sptr += 2;
+-	    /* raw memcpy (fix include autoconf later) */
+-	    sys_memcpy(sptr, (char*)(&ifreq.ifr_hwaddr.sa_data), IFHWADDRLEN);
+-	    sptr += IFHWADDRLEN;
+-#elif defined(SIOCGENADDR)
++#if defined(SIOCGENADDR)
+ 	    if (ioctl(desc->s, SIOCGENADDR, (char *)&ifreq) < 0)
+ 		break;
+ 	    buf_check(sptr, s_end, 1+2+sizeof(ifreq.ifr_enaddr));
+EOF
+            fi
+        ;;
         *)
         ;;
     esac
 
-    assert_valid_release $1
-    assert_build_name_unused $2
-
-    FILENAME=otp_src_$1.tar.gz
-    download "$FILENAME"
-    mkdir -p "$KERL_BUILD_DIR/$2"
-    if [ ! -d "$KERL_BUILD_DIR/$2/otp_src_$1" ]; then
-        echo "Extracting source code"
-        cd "$KERL_BUILD_DIR/$2" && tar xfz "$KERL_DOWNLOAD_DIR/$FILENAME"
-    fi
-    echo "Building Erlang/OTP $1 ($2), please wait..."
-    ERL_TOP="$KERL_BUILD_DIR/$2/otp_src_$1"
-    cd "$ERL_TOP"
     LOGFILE="$KERL_BUILD_DIR/$2/otp_build_$1.log"
     if [ -n "$KERL_USE_AUTOCONF" ]; then
         ./otp_build setup -a $KERL_CONFIGURE_OPTIONS > "$LOGFILE" 2>&1
@@ -535,6 +564,11 @@ get_name_from_install_path()
         grep -F "$1" "$KERL_BASE_DIR/otp_installations" | cut -d ' ' -f 1
     fi
     return 0
+}
+
+get_release()
+{
+    echo "$1" | sed $SED_OPT -e 's/R([0-9]+).+/\1/'
 }
 
 do_active()


### PR DESCRIPTION
Tested on OpenIndiana oi_151a.  The embedded patch to inet_drv.c has been tested on Solaris 10 and newer, though GNU sed is necessary for kerl to function overall.