### PR TITLE
Fix md5 handling on FreeBSD.

### DIFF
--- a/kerl
+++ b/kerl
@@ -84,7 +84,7 @@ fi
 
 KERL_SYSTEM=`uname -s`
 case "$KERL_SYSTEM" in
-    Darwin|OpenBSD)
+    Darwin|FreeBSD|OpenBSD)
         MD5SUM="openssl md5"
         MD5SUM_FIELD=2
         SED_OPT=-E


### PR DESCRIPTION
FreeBSD also doesn't have md5sum, it has either a command named md5 or
openssl in the base system.  Added FreeBSD to the list of openssl using OS.
