### PR TITLE
fixes related to grep exit code handling

### DIFF
--- a/kerl
+++ b/kerl
@@ -303,7 +303,7 @@ do_git_build()
     fi
     cd otp_src_git
     git branch -a | grep "$2" > /dev/null 2>&1
-    if [ $? -ne 0 ]; then
+    if [ $? -eq 0 ]; then
         git checkout $2 > /dev/null 2>&1
     else
         git checkout -b $2 origin/$2 > /dev/null 2>&1


### PR DESCRIPTION
EXIT STATUS
       The  exit status is 0 if selected lines are found, and 1 if not found.  If an error occurred the exit status is 2.  (Note: POSIX error handling code should check for '2'
       or greater.)
