### PR TITLE
Removed typo.

### DIFF
--- a/kerl
+++ b/kerl
@@ -795,6 +795,6 @@ case "$1" in
         esac
         ;;
     *)
-        echo "unkwnown command: $1"; usage; exit 1
+        echo "unknown command: $1"; usage; exit 1
         ;;
 esac


### PR DESCRIPTION
Minor one but removed a typo when printing out an unknown command error.
