### PR TITLE
Fix: do not hardcode origin/ to ref (enables R16A)

### DIFF
--- a/kerl
+++ b/kerl
@@ -260,7 +260,7 @@ do_git_build()
     if [ $? -eq 0 ]; then
         git checkout $2 > /dev/null 2>&1
     else
-        git checkout -b $2 origin/$2 > /dev/null 2>&1
+        git checkout -b $2 $2 > /dev/null 2>&1
     fi
     if [ $? -ne 0 ]; then
         echo "Couldn't checkout specified version"


### PR DESCRIPTION
This allows building tags and all other funny kinds of refs.

This patch enables you to build R16A:

```
$ kerl build git git://github.com/erlang/otp.git OTP_R16A_RELEASE_CANDIDATE r16a
```
