### PR TITLE
Expand regex for matching http://www.erlang.org/download releases

### DIFF
--- a/kerl
+++ b/kerl
@@ -114,7 +114,7 @@ if [ $# -eq 0 ]; then usage; fi
 get_releases()
 {
     curl -s $ERLANG_DOWNLOAD_URL/ | \
-        sed $SED_OPT -e 's/^.*<[aA] [hH][rR][eE][fF]=\"\/download\/otp_src_(R1[-1234567890ABCD]+)\.tar\.gz\">.*$/\1/' \
+        sed $SED_OPT -e 's/^.*<[aA] [hH][rR][eE][fF]=\"\/download\/otp_src_(R1[-0-9A-Za-z_]+)\.tar\.gz\">.*$/\1/' \
                      -e '/^R/!d'
 }
 


### PR DESCRIPTION
The previous regex did not match with the R16A release available for
download from the Erlang/OTP website.
