### PR TITLE
Add support for disabling apps to build via KERL_CONFIGURE_DISABLE_APPLICATIONS

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ You can set the following variables:
 - KERL_DEFAULT_INSTALL_DIR if set in ~/.kerlrc, install builds to this dir if no path is provided on installs, (recommend "$KERL_BASE_DIR/installs")
 - KERL_CONFIGURE_OPTIONS options to pass to Erlang's ./configure script, e.g. --without-termcap
 - KERL_CONFIGURE_APPLICATIONS if non-empty, subset of applications used in the builds (and subsequent installations) process, e.g. "kernel stdlib sasl"
+- KERL_CONFIGURE_DISABLE_APPLICATIONS if non-empty, subset of applications disabled in the builds (and subsequent installations) process, e.g. "odbc"
 - KERL_SASL_STARTUP use SASL system startup instead of minimal
 - KERL_USE_AUTOCONF use autoconf in the builds process
 - KERL_INSTALL_MANPAGES if non-empty will install manpages
@@ -203,6 +204,12 @@ You can specify the configure options to use when building Erlang/OTP with the K
 If non-empty, you can specify the subset of applications to use when building (and subsequent installing) Erlang/OTOP with the KERL_CONFIGURE_APPLICATIONS variable, either in your $HOME/.kerlrc file or prepending it to the command line.
 
     $ KERL_CONFIGURE_APPLICATIONS="kernel stdlib sasl" kerl build R15B01 r15b01_minimal
+
+#### Configure disable applications
+
+If non-empty, you can specify the subset of applications to disable when building (and subsequent installing) Erlang/OTOP with the KERL_CONFIGURE_DISABLE_APPLICATIONS variable, either in your $HOME/.kerlrc file or prepending it to the command line.
+
+    $ KERL_CONFIGURE_DISABLE_APPLICATIONS="odbc" kerl build R16B02 r16b02_no_odbc
 
 #### Enable autoconf
 

--- a/kerl
+++ b/kerl
@@ -34,6 +34,9 @@ fi
 if [ -n "$KERL_CONFIGURE_APPLICATIONS" ]; then
     _KCA="$KERL_CONFIGURE_APPLICATIONS"
 fi
+if [ -n "$KERL_CONFIGURE_DISABLE_APPLICATIONS" ]; then
+    _KCDA="$KERL_CONFIGURE_DISABLE_APPLICATIONS"
+fi
 if [ -n "$KERL_SASL_STARTUP" ]; then
     _KSS="$KERL_SASL_STARTUP"
 fi
@@ -45,6 +48,7 @@ if [ -n "$KERL_DEPLOY_RSYNC_OPTIONS" ]; then
 fi
 KERL_CONFIGURE_OPTIONS=
 KERL_CONFIGURE_APPLICATIONS=
+KERL_CONFIGURE_DISABLE_APPLICATIONS=
 KERL_SASL_STARTUP=
 KERL_INSTALL_MANPAGES=
 
@@ -59,6 +63,9 @@ if [ -n "$_KCO" ]; then
 fi
 if [ -n "$_KCA" ]; then
     KERL_CONFIGURE_APPLICATIONS="$_KCA"
+fi
+if [ -n "$_KCDA" ]; then
+    KERL_CONFIGURE_DISABLE_APPLICATIONS="$_KCDA"
 fi
 if [ -n "$_KSS" ]; then
     KERL_SASL_STARTUP="$_KSS"
@@ -292,6 +299,15 @@ do_git_build()
             fi
         done
     fi
+    if [ -n "$KERL_CONFIGURE_DISABLE_APPLICATIONS" ]; then
+        for i in $KERL_CONFIGURE_DISABLE_APPLICATIONS; do
+            touch -f ./lib/$i/SKIP
+            if [ $? -ne 0 ]; then
+                echo "Couldn't disable '$i' application for building"
+                exit 1
+            fi
+        done
+    fi
     ./otp_build boot -a $KERL_CONFIGURE_OPTIONS > "$LOGFILE" 2>&1
     if [ $? -ne 0 ]; then
         echo "Build error, see $LOGFILE"
@@ -362,6 +378,15 @@ do_build()
             if [ $? -ne 0 ]; then
                 echo "Couldn't prepare '$i' application for building"
                 list_remove builds "$1 $2"
+                exit 1
+            fi
+        done
+    fi
+    if [ -n "$KERL_CONFIGURE_DISABLE_APPLICATIONS" ]; then
+        for i in $KERL_CONFIGURE_DISABLE_APPLICATIONS; do
+            touch -f ./lib/$i/SKIP
+            if [ $? -ne 0 ]; then
+                echo "Couldn't disable '$i' application for building"
                 exit 1
             fi
         done


### PR DESCRIPTION
If non-empty, you can specify the subset of applications to disable when
building (and subsequent installing) Erlang/OTOP with the
KERL_CONFIGURE_DISABLE_APPLICATIONS variable, either in your $HOME/.kerlrc
file or prepending it to the command line.

e.g. KERL_CONFIGURE_DISABLE_APPLICATIONS="odbc"
