### PR TITLE
Update kerl to accept new version numbering scheme since 17.0-rc1

### DIFF
--- a/kerl
+++ b/kerl
@@ -121,8 +121,8 @@ if [ $# -eq 0 ]; then usage; fi
 get_releases()
 {
     curl -s $ERLANG_DOWNLOAD_URL/ | \
-        sed $SED_OPT -e 's/^.*<[aA] [hH][rR][eE][fF]=\"\/download\/otp_src_(R1[-0-9A-Za-z_]+)\.tar\.gz\">.*$/\1/' \
-                     -e '/^R/!d'
+        sed $SED_OPT -e 's/^.*<[aA] [hH][rR][eE][fF]=\"\/download\/otp_src_([-0-9A-Za-z_.]+)\.tar\.gz\">.*$/\1/' \
+                     -e '/^R1|^[0-9]/!d'
 }
 
 update_checksum_file()


### PR DESCRIPTION
- Change get_releases() to accept the new naming scheme of
  `otp_src_MAJOR.MINOR.PATCH.tar.gz`, where MAJOR, MINOR, PATCH
  are all decimal letters and some additional letters in
  `[-0-9A-Za-z_.]` (see OTP-11615 on otp_src_17.0-rc1.tar.gz)
