### PR TITLE
Fix raw path for kerl download

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Downloading
 
 You can download the script directly from github:
 
-    $ curl -O https://raw.github.com/spawngrid/kerl/master/kerl
+    $ curl -O https://raw.githubusercontent.com/spawngrid/kerl/master/kerl
 
 Then ensure it is executable
 


### PR DESCRIPTION
The `curl` command kept silently failing, finally ran with `-i`:

```
$ curl -i https://raw.github.com/spawngrid/kerl/master/kerl
HTTP/1.1 301 Moved Permanently
Date: Sun, 27 Apr 2014 01:21:14 GMT
Server: Apache
Location: https://raw.githubusercontent.com/spawngrid/kerl/master/kerl
```

Hostname updated in README (could alternatively or additionally add `-L` as an argument to `curl`)
