### PR TITLE
add support for fish shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,22 @@ Since .kerlrc is a dot file for `/bin/sh`, running shell commands inside the
 executed later. For example, the shell `export` commands in .kerlrc will affect
 *your login shell environment* when activating `curl`.  Use with care.
 
+Fish shell support
+------------------
+
+kerl has basic support for the fish shell.
+
+To activate an installation:
+
+    source /path/to/install/dir/activate.fish
+
+Deactivation is the same as in other shells:
+
+    kerl_deactivate
+
+Please note: if you've installed a build with an older version of kerl
+(1.2 or older) it won't have the `activate.fish` script.
+
 Glossary
 --------
 

--- a/kerl
+++ b/kerl
@@ -668,6 +668,70 @@ if [ -n "\$BASH" -o -n "\$ZSH_VERSION" ]; then
     hash -r
 fi
 ACTIVATE
+
+    cat <<ACTIVATE_FISH > "$absdir/activate.fish"
+# credits to virtualenv
+function _kerl_remove_el --description 'remove element from array'
+    set -l new_array
+    for el in \$\$argv[1]
+        if test \$el != \$argv[2]
+            set new_array \$new_array \$el
+        end
+    end
+    set -x \$argv[1] \$new_array
+end
+
+function kerl_deactivate --description "deactivate erlang environment"
+    if set --query _KERL_PATH_REMOVABLE
+        _kerl_remove_el PATH "\$_KERL_PATH_REMOVABLE"
+        set --erase _KERL_PATH_REMOVABLE
+    end
+    if set --query _KERL_MANPATH_REMOVABLE
+        _kerl_remove_el MANPATH "\$_KERL_MANPATH_REMOVABLE"
+        set --erase _KERL_MANPATH_REMOVABLE
+    end
+    if set --query _KERL_SAVED_REBAR_PLT_DIR
+        set -x REBAR_PLT_DIR "\$_KERL_SAVED_REBAR_PLT_DIR"
+        set --erase _KERL_SAVED_REBAR_PLT_DIR
+    end
+    if set --query _KERL_ACTIVE_DIR
+        set --erase _KERL_ACTIVE_DIR
+    end
+    if functions --query _kerl_saved_prompt
+        functions --erase fish_prompt
+        # functions --copy complains about about fish_prompt already being defined
+        # so we take a page from virtualenv's book
+        . ( begin
+                printf "function fish_prompt\n\t#"
+                functions _kerl_saved_prompt
+            end | psub )
+        functions --erase _kerl_saved_prompt
+    end
+    if test "\$argv[1]" != "nondestructive"
+        functions --erase kerl_deactivate
+        functions --erase _kerl_remove_el
+    end
+end
+kerl_deactivate nondestructive
+
+set -x _KERL_SAVED_REBAR_PLT_DIR "\$REBAR_PLT_DIR"
+set -x _KERL_PATH_REMOVABLE "$absdir/bin"
+set -x PATH \$PATH "\$_KERL_PATH_REMOVABLE"
+set -x _KERL_MANPATH_REMOVABLE "$absdir/lib/erlang/man" "$absdir/man"
+set -x MANPATH \$MANPATH "\$_KERL_MANPATH_REMOVABLE"
+set -x REBAR_PLT_DIR "$absdir"
+set -x _KERL_ACTIVE_DIR "$absdir"
+if test -f "$KERL_CONFIG.fish"
+    source "$KERL_CONFIG.fish"
+end
+if set --query KERL_ENABLE_PROMPT
+    functions --copy fish_prompt _kerl_saved_prompt
+    function fish_prompt
+        echo -n "($1)"
+        _kerl_saved_prompt
+    end
+end
+ACTIVATE_FISH
     if [ -n "$KERL_BUILD_DOCS" ]; then
         DOC_DIR="$KERL_BUILD_DIR/$1/release_$rel/lib/erlang"
         if [ -d "$DOC_DIR" ]; then


### PR DESCRIPTION
adds `activate.fish` script to installations
`activate.fish` will source `~/.kerlrc.fish` if vailable since `~/.kerlrc` will not be syntax compatible