### PR TITLE
Address install issues

### DIFF
--- a/kerl
+++ b/kerl
@@ -422,7 +422,7 @@ do_build()
     fi
     if [ $? -ne 0 ]; then
         echo "Build failed:"
-        tail $LOGFILE
+        tail "$LOGFILE"
         echo
         echo "Please see $LOGFILE for full details."
         list_remove builds "$1 $2"

--- a/kerl
+++ b/kerl
@@ -421,7 +421,10 @@ do_build()
 
     fi
     if [ $? -ne 0 ]; then
-        echo "Build failed, see $LOGFILE"
+        echo "Build failed:"
+        tail $LOGFILE
+        echo
+        echo "Please see $LOGFILE for full details."
         list_remove builds "$1 $2"
         exit 1
     fi

--- a/kerl
+++ b/kerl
@@ -219,12 +219,14 @@ get_release_from_name()
 get_newest_valid_release()
 {
     check_releases
-    while read -r rel; do
-        if [ ! -z "$rel" ]; then
-            echo "$rel"
-            return 0
-        fi
-    done < "$KERL_BASE_DIR"/otp_releases | tail -1
+
+    rel=$(tail -1 "$KERL_BASE_DIR"/otp_releases)
+
+    if [ ! -z "$rel" ]; then
+        echo "$rel"
+        return 0
+    fi
+
     return 1
 }
 

--- a/kerl
+++ b/kerl
@@ -367,12 +367,7 @@ do_build()
                             xc_ssl='/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift-migrator/sdk/MacOSX.sdk/usr'
                             if [ -d "$xc_ssl/include/openssl" ]
                             then
-                                if [ $RELVERSION -ge 17 ]
-                                then
-                                    KERL_CONFIGURE_OPTIONS="$KERL_CONFIGURE_OPTIONS --with-ssl --with-ssl-incl=$xc_ssl"
-                                else
-                                    KERL_CONFIGURE_OPTIONS="$KERL_CONFIGURE_OPTIONS --with-ssl=$xc_ssl"
-                                fi
+                                KERL_CONFIGURE_OPTIONS="$KERL_CONFIGURE_OPTIONS --with-ssl=$xc_ssl"
                             else
                                 echo 'WARNING: No OpenSSL library was found in the usual places. Your Erlang will be built without crypto support!'
                             fi


### PR DESCRIPTION
Addresses #120 

These changes include the following:
* rewrite `get_newest_valid_release()` to be simpler - the old way set up a while loop but it only ever has a single value.  So let's just put it in a variable and test it.
* Got a build error when I set the `./configure` script to use `--with-ssl` with no path and `--with-ssl-incl`. Just go back to using `--with-ssl=PATH` as before. (Linked to #110)
* If a build fails, tail the last bit of the log file automatically.

I have successfully built and installed 18.3 from a tarball and the basho10 tag from a git build.