### PR TITLE
Allow a custom Github URL

### DIFF
--- a/kerl
+++ b/kerl
@@ -65,6 +65,9 @@ fi
 if [ -n "$KERL_BUILD_DOCS" ]; then
     _KBD="$KERL_BUILD_DOCS"
 fi
+if [ -n "$KERL_BUILD_BACKEND" ]; then
+    _KBB="$KERL_BUILD_BACKEND"
+fi
 OTP_GITHUB_URL=
 KERL_CONFIGURE_OPTIONS=
 KERL_CONFIGURE_APPLICATIONS=
@@ -75,6 +78,7 @@ KERL_DEPLOY_RSYNC_OPTIONS=
 KERL_INSTALL_MANPAGES=
 KERL_BUILD_PLT=
 KERL_BUILD_DOCS=
+KERL_BUILD_BACKEND=
 
 # ensure the base dir exists
 mkdir -p "$KERL_BASE_DIR" || exit 1
@@ -111,6 +115,9 @@ if [ -n "$_KBPLT" ]; then
 fi
 if [ -n "$_KBD" ]; then
     KERL_BUILD_DOCS="$_KBD"
+fi
+if [ -n "$_KBB" ]; then
+    KERL_BUILD_BACKEND="$_KBB"
 fi
 
 if [ -z "$KERL_SASL_STARTUP" ]; then

--- a/kerl
+++ b/kerl
@@ -26,15 +26,18 @@
 GREP_OPTIONS=''
 
 ERLANG_DOWNLOAD_URL="http://www.erlang.org/download"
-OTP_GITHUB_URL="https://github.com/erlang/otp"
 
 # Default values
+: ${OTP_GITHUB_URL:="https://github.com/erlang/otp"}
 : ${KERL_BASE_DIR:="$HOME"/.kerl}
 : ${KERL_CONFIG:="$HOME"/.kerlrc}
 : ${KERL_DOWNLOAD_DIR:="${KERL_BASE_DIR:?}"/archives}
 : ${KERL_BUILD_DIR:="${KERL_BASE_DIR:?}"/builds}
 : ${KERL_GIT_DIR:="${KERL_BASE_DIR:?}"/gits}
 
+if [ -n "$OTP_GITHUB_URL" ]; then
+    _OGU="$OTP_GITHUB_URL"
+fi
 if [ -n "$KERL_CONFIGURE_OPTIONS" ]; then
     _KCO="$KERL_CONFIGURE_OPTIONS"
 fi
@@ -62,6 +65,7 @@ fi
 if [ -n "$KERL_BUILD_DOCS" ]; then
     _KBD="$KERL_BUILD_DOCS"
 fi
+OTP_GITHUB_URL=
 KERL_CONFIGURE_OPTIONS=
 KERL_CONFIGURE_APPLICATIONS=
 KERL_CONFIGURE_DISABLE_APPLICATIONS=
@@ -78,6 +82,9 @@ mkdir -p "$KERL_BASE_DIR" || exit 1
 # source the config file if available
 if [ -f "$KERL_CONFIG" ]; then . "$KERL_CONFIG"; fi
 
+if [ -n "$_OGU" ]; then
+    OTP_GITHUB_URL="$_OGU"
+fi
 if [ -n "$_KCO" ]; then
     KERL_CONFIGURE_OPTIONS="$_KCO"
 fi

--- a/kerl
+++ b/kerl
@@ -176,10 +176,8 @@ get_releases()
 {
     if [ "$KERL_BUILD_BACKEND" = "git" ]
     then
-        echo "Getting the available releases from github.com..."
         get_git_releases
     else
-        echo "Getting the available releases from erlang.org..."
         get_tarball_releases
     fi
 }


### PR DESCRIPTION
Set `OTP_GITHUB_URL` to a fork of OTP on github and you'll be able to build from tags there.
Also:
 - allow setting `KERL_BUILD_BACKEND` from env and .kerlrc
 - suppress a couple of log lines that were ending up inside `$KERL_BASE_DIR/otp_releases` erroneously

e.g.
``` bash
$ export OTP_GITHUB_URL="https://github.com/basho/otp"
$ kerl update releases
The available releases are:
... R16B02_basho10 R16B02_basho10rc1 R16B02_basho10rc2 R16B02_basho10rc3 R16B02_basho2 R16B02_basho3 R16B02_basho4 R16B02_basho5 R16B02_basho6 R16B02_basho7 R16B02_basho8 R16B02_basho9 R16B02_basho9rc1 ...
```