### PR TITLE
Github tags before OTP 17 use underscore

### DIFF
--- a/kerl
+++ b/kerl
@@ -367,7 +367,7 @@ do_git_build()
 
 get_otp_version()
 {
-    echo $1 | sed $SED_OPT -e 's/R?([0-9]{1,2})[.AB]?[0-9]*/\1/'
+    echo $1 | sed $SED_OPT -e 's/R?([0-9]{1,2})[.AB]?[0-9-]*/\1/'
 }
 
 show_logfile()
@@ -390,7 +390,7 @@ do_normal_build()
         UNTARDIRNAME="$KERL_BUILD_DIR/$2/$FILENAME-kerluntar-$$"
         rm -rf "$UNTARDIRNAME"
         mkdir -p "$UNTARDIRNAME" || exit 1
-        # github tarballs have a directory in the form of "otp-TAGNAME"
+        # github tarballs have a directory in the form of "otp[_-]TAGNAME"
         # Ericsson tarballs have the classic otp_src_RELEASE pattern
         # Standardize on Ericsson format because that's what the rest of the script expects
         (cd "$UNTARDIRNAME" && tar xfz "$KERL_DOWNLOAD_DIR/$FILENAME.tar.gz" && mv ./* "$KERL_BUILD_DIR/$2/otp_src_$1")
@@ -962,11 +962,21 @@ do_active()
     fi
 }
 
+make_filename()
+{
+    release=$(get_otp_version "$1")
+    if [ $release -ge 17 ]; then
+        echo "OTP-$1"
+    else
+        echo "OTP_$1"
+    fi
+}
+
 download()
 {
     mkdir -p "$KERL_DOWNLOAD_DIR" || exit 1
     if [ "$KERL_BUILD_BACKEND" = "git" ]; then
-        FILENAME="OTP-$1"
+        FILENAME=$(make_filename "$1")
         github_download "$FILENAME.tar.gz"
     else
         FILENAME="otp_src_$1"


### PR DESCRIPTION
If the build backend is `git` and you choose a tag that's greater than or equal to 17, then the download tarball is `OTP-XX` otherwise it's `OTP_YY`

Also fixes a problem in the regex of `get_otp_version()` where releases like `R15B03-1` weren't properly handled.