### PR TITLE
Improve use of 'curl' in kerl script

### DIFF
--- a/kerl
+++ b/kerl
@@ -206,7 +206,7 @@ update_checksum_file()
         return 0
     else
         echo "Getting the checksum file from erlang.org..."
-        curl -L $ERLANG_DOWNLOAD_URL/MD5 > "$KERL_DOWNLOAD_DIR"/MD5 || exit 1
+        curl -L -o "$KERL_DOWNLOAD_DIR/MD5" "$ERLANG_DOWNLOAD_URL/MD5" || exit 1
     fi
 }
 
@@ -985,14 +985,14 @@ github_download()
 {
     if [ ! -f "$KERL_DOWNLOAD_DIR/$1" ]; then
         echo "Downloading $1 to $KERL_DOWNLOAD_DIR"
-        curl -L "$OTP_GITHUB_URL/archive/$1" > "$KERL_DOWNLOAD_DIR/$1"
+        curl -L -o "$KERL_DOWNLOAD_DIR/$1" "$OTP_GITHUB_URL/archive/$1"
     fi
 }
 
 tarball_download()
 {
     if [ ! -f "$KERL_DOWNLOAD_DIR/$1" ]; then
-        curl -L "$ERLANG_DOWNLOAD_URL/$1" > "$KERL_DOWNLOAD_DIR/$1"
+        curl -L -o "$KERL_DOWNLOAD_DIR/$1" "$ERLANG_DOWNLOAD_URL/$1"
         update_checksum_file
     fi
     ensure_checksum_file

--- a/kerl
+++ b/kerl
@@ -193,7 +193,7 @@ get_git_releases()
 
 get_tarball_releases()
 {
-    curl -L -s $ERLANG_DOWNLOAD_URL/ | \
+    curl -q -L -s $ERLANG_DOWNLOAD_URL/ | \
         sed $SED_OPT -e 's/^.*<[aA] [hH][rR][eE][fF]=\"\otp_src_([-0-9A-Za-z_.]+)\.tar\.gz\">.*$/\1/' \
                      -e '/^R1|^[0-9]/!d' | \
         sed -e "s/^R\(.*\)/\1:R\1/" | sed -e "s/^\([^\:]*\)$/\1-z:\1/" | sort | cut -d':' -f2


### PR DESCRIPTION
1. __Make kerl use 'curl -o $filename ...' when downloading files__

    Instead of piping output to a file, use curl's '-o' option.

    This change is intended to work around a problem I encountered where I had `-w "\n"` in my `~/.curlrc` file, which caused these commands to produce output that failed the md5 checks.

1. __Use 'curl -q' in 'get_tarball_releases()'__

    This bypasses processing `~/.curlrc`, eliminating the chance that options set in that file may result in errant, unexpected behavior from this curl call.