### PR TITLE
Add patches to build older OTP releases

### DIFF
--- a/kerl
+++ b/kerl
@@ -370,10 +370,9 @@ get_otp_version()
     echo $1 | sed $SED_OPT -e 's/R?([0-9]{1,2})[.AB]?[-.0-9rc]*/\1/'
 }
 
-get_javac_version()
+get_perl_version()
 {
-    javaout=$(javac -version 2>&1)
-    echo "$javaout" | cut -d' ' -f2 | cut -d'.' -f2
+    perl -v | grep version | sed $SED_OPT -e 's/.*v5\.([0-9]+)\.[0-9].*/\1/'
 }
 
 get_javac_version()
@@ -412,8 +411,22 @@ maybe_patch()
 
 maybe_patch_all()
 {
+    perlver=$(get_perl_version)
+    if [ "$perlver" -ge 24 ]; then
+        case "$1" in
+            14)
+                apply_r14_beam_makeops_patch >> "$LOGFILE"
+                ;;
+            15)
+                apply_r15_beam_makeops_patch >> "$LOGFILE"
+                ;;
+            *)
+                ;;
+        esac
+    fi
+
     # Are we building docs?
-    if [ "$KERL_BUILD_DOCS" ]; then
+    if [ -n "$KERL_BUILD_DOCS" ]; then
         if [ "$1" -le 16 ]; then
             javaver=$(get_javac_version)
             if [ "$javaver" -ge 8 ]; then
@@ -1163,6 +1176,41 @@ apply_javadoc_linting_patch()
  		-windowtitle $(JAVADOC_TITLE) $(JAVADOC_PKGS))
  
  man: 
+_END_PATCH
+}
+
+# perl 5.24 fatalizes the warning this causes
+apply_r14_beam_makeops_patch()
+{
+    patch -p0 <<'_END_PATCH'
+--- erts/emulator/utils/beam_makeops.orig	2016-05-23 21:40:42.000000000 -0500
++++ erts/emulator/utils/beam_makeops	2016-05-23 21:41:08.000000000 -0500
+@@ -1576,7 +1576,7 @@
+ 	if $min_window{$key} > $min_window;
+ 
+     pop(@{$gen_transform{$key}})
+-	if defined @{$gen_transform{$key}}; # Fail
++	if defined $gen_transform{$key}; # Fail
+     my(@prefix) = (&make_op($comment), &make_op('', 'try_me_else', &tr_code_len(@code)));
+     unshift(@code, @prefix);
+     push(@{$gen_transform{$key}}, @code, &make_op('', 'fail'));
+_END_PATCH
+}
+
+# https://github.com/erlang/otp/commit/21ca6d3a137034f19862db769a5b7f1c5528dbc4.diff
+apply_r15_beam_makeops_patch()
+{
+    patch -p1 <<'_END_PATCH'
+--- a/erts/emulator/utils/beam_makeops
++++ b/erts/emulator/utils/beam_makeops
+@@ -1711,7 +1711,7 @@ sub tr_gen_to {
+     my $prev_last;
+     $prev_last = pop(@{$gen_transform{$key}})
+-	if defined @{$gen_transform{$key}}; # Fail
++	if defined $gen_transform{$key}; # Fail
+ 
+     if ($prev_last && !is_instr($prev_last, 'fail')) {
+ 	error("Line $line: A previous transformation shadows '$orig_transform'");
 _END_PATCH
 }
 

--- a/kerl
+++ b/kerl
@@ -378,23 +378,6 @@ show_logfile()
     echo "Please see $2 for full details."
 }
 
-download_patch()
-{
-    TMPFILE=$(mktemp) || exit 1
-    curl -sL "$OTP_GITHUB_URL/commit/$1" > "$TMPFILE"
-    if [ $? -ne 0 ]; then
-        echo "ERROR: Couldn't download patch $OTP_GITHUB_URL/commit/$1"
-        rm "$TMPFILE"
-        exit 1
-    fi
-    echo "$TMPFILE"
-}
-
-apply_patch()
-{
-    patch -p1 < "$1" >> "$LOGFILE"
-}
-
 maybe_patch()
 {
     # $1 = OS platform e.g., Darwin, etc
@@ -403,14 +386,11 @@ maybe_patch()
     case "$1" in
         Darwin)
             maybe_patch_darwin "$2"
-            maybe_patch_all "$2"
             ;;
         SunOS)
             maybe_patch_sunos "$2"
-            maybe_patch_all "$2"
             ;;
         *)
-            maybe_patch_all "$2"
             ;;
     esac
 }
@@ -419,9 +399,7 @@ maybe_patch_darwin()
 {
     release=$(get_otp_version "$1")
     if [ "$release" -le 14 ]; then
-        filename=$(download_patch "687dfb57c61ef9a777f706b73b14da93aa3ea448.patch")
-        apply_patch "$filename"
-        rm "$filename"
+        apply_darwin_patch >> "$LOGFILE"
     fi
 }
 
@@ -429,19 +407,7 @@ maybe_patch_sunos()
 {
     release=$(get_otp_version "$1")
     if [ "$release" -le 14 ]; then
-        filename=$(download_patch "8e5ef86ee21cb6491287710606a7525f45cc50fc.patch")
-        apply_patch "$filename"
-        rm "$filename"
-    fi
-}
-
-maybe_patch_all()
-{
-    release=$(get_otp_version "$1")
-    if [ "$release" -le 16 ]; then
-        filename=$(download_patch "21ca6d3a137034f19862db769a5b7f1c5528dbc4.patch")
-        apply_patch "$filename"
-        rm "$filename"
+        apply_solaris_networking_patch >> "$LOGFILE"
     fi
 }
 
@@ -551,7 +517,7 @@ _do_build()
             fi
         done
     fi
-    ./otp_build boot -a $KERL_CONFIGURE_OPTIONS > "$LOGFILE" 2>&1
+    ./otp_build boot -a $KERL_CONFIGURE_OPTIONS >> "$LOGFILE" 2>&1
     if [ $? -ne 0 ]; then
         show_logfile "Build failed." "$LOGFILE"
         list_remove builds "$1 $2"
@@ -1076,6 +1042,81 @@ tarball_download()
         exit 1
     fi
     echo "Checksum verified ($SUM)"
+}
+
+apply_solaris_networking_patch()
+{
+    patch -p1 <<_END_PATCH
+--- otp-a/erts/emulator/drivers/common/inet_drv.c
++++ otp-b/erts/emulator/drivers/common/inet_drv.c
+@@ -4166,16 +4166,7 @@
+ 	    break;
+
+ 	case INET_IFOPT_HWADDR: {
+-#ifdef SIOCGIFHWADDR
+-	    if (ioctl(desc->s, SIOCGIFHWADDR, (char *)&ifreq) < 0)
+-		break;
+-	    buf_check(sptr, s_end, 1+2+IFHWADDRLEN);
+-	    *sptr++ = INET_IFOPT_HWADDR;
+-	    put_int16(IFHWADDRLEN, sptr); sptr += 2;
+-	    /* raw memcpy (fix include autoconf later) */
+-	    sys_memcpy(sptr, (char*)(&ifreq.ifr_hwaddr.sa_data), IFHWADDRLEN);
+-	    sptr += IFHWADDRLEN;
+-#elif defined(SIOCGENADDR)
++#if defined(SIOCGENADDR)
+ 	    if (ioctl(desc->s, SIOCGENADDR, (char *)&ifreq) < 0)
+ 		break;
+ 	    buf_check(sptr, s_end, 1+2+sizeof(ifreq.ifr_enaddr));
+_END_PATCH
+}
+
+apply_darwin_patch()
+{
+    patch -p0 <<_END_PATCH
+--- erts/emulator/beam/beam_bp.c.orig	2011-10-03 13:12:07.000000000 -0500
++++ erts/emulator/beam/beam_bp.c	2013-10-04 13:42:03.000000000 -0500
+@@ -496,7 +496,8 @@
+ }
+
+ /* bp_hash */
+-ERTS_INLINE Uint bp_sched2ix() {
++#ifndef ERTS_DO_INCL_GLB_INLINE_FUNC_DEF
++ERTS_GLB_INLINE Uint bp_sched2ix() {
+ #ifdef ERTS_SMP
+     ErtsSchedulerData *esdp;
+     esdp = erts_get_scheduler_data();
+@@ -505,6 +506,7 @@
+     return 0;
+ #endif
+ }
++#endif
+ static void bp_hash_init(bp_time_hash_t *hash, Uint n) {
+     Uint size = sizeof(bp_data_time_item_t)*n;
+     Uint i;
+--- erts/emulator/beam/beam_bp.h.orig	2011-10-03 13:12:07.000000000 -0500
++++ erts/emulator/beam/beam_bp.h	2013-10-04 13:42:08.000000000 -0500
+@@ -144,7 +144,19 @@
+ #define ErtsSmpBPUnlock(BDC)
+ #endif
+
+-ERTS_INLINE Uint bp_sched2ix(void);
++ERTS_GLB_INLINE Uint bp_sched2ix(void);
++
++#ifdef ERTS_DO_INCL_GLB_INLINE_FUNC_DEF
++ERTS_GLB_INLINE Uint bp_sched2ix() {
++#ifdef ERTS_SMP
++    ErtsSchedulerData *esdp;
++    esdp = erts_get_scheduler_data();
++    return esdp->no - 1;
++#else
++    return 0;
++#endif
++}
++#endif
+
+ #ifdef ERTS_SMP
+ #define bp_sched2ix_proc(p) ((p)->scheduler_data->no - 1)
+_END_PATCH
 }
 
 case "$1" in

--- a/kerl
+++ b/kerl
@@ -378,6 +378,73 @@ show_logfile()
     echo "Please see $2 for full details."
 }
 
+download_patch()
+{
+    TMPFILE=$(mktemp) || exit 1
+    curl -sL "$OTP_GITHUB_URL/commit/$1" > "$TMPFILE"
+    if [ $? -ne 0 ]; then
+        echo "ERROR: Couldn't download patch $OTP_GITHUB_URL/commit/$1"
+        rm "$TMPFILE"
+        exit 1
+    fi
+    echo "$TMPFILE"
+}
+
+apply_patch()
+{
+    patch -p1 < "$1" >> "$LOGFILE"
+}
+
+maybe_patch()
+{
+    # $1 = OS platform e.g., Darwin, etc
+    # $2 = OTP release
+
+    case "$1" in
+        Darwin)
+            maybe_patch_darwin "$2"
+            maybe_patch_all "$2"
+            ;;
+        SunOS)
+            maybe_patch_sunos "$2"
+            maybe_patch_all "$2"
+            ;;
+        *)
+            maybe_patch_all "$2"
+            ;;
+    esac
+}
+
+maybe_patch_darwin()
+{
+    release=$(get_otp_version "$1")
+    if [ "$release" -le 14 ]; then
+        filename=$(download_patch "687dfb57c61ef9a777f706b73b14da93aa3ea448.patch")
+        apply_patch "$filename"
+        rm "$filename"
+    fi
+}
+
+maybe_patch_sunos()
+{
+    release=$(get_otp_version "$1")
+    if [ "$release" -le 14 ]; then
+        filename=$(download_patch "8e5ef86ee21cb6491287710606a7525f45cc50fc.patch")
+        apply_patch "$filename"
+        rm "$filename"
+    fi
+}
+
+maybe_patch_all()
+{
+    release=$(get_otp_version "$1")
+    if [ "$release" -le 16 ]; then
+        filename=$(download_patch "21ca6d3a137034f19862db769a5b7f1c5528dbc4.patch")
+        apply_patch "$filename"
+        rm "$filename"
+    fi
+}
+
 do_normal_build()
 {
     assert_valid_release "$1"
@@ -443,6 +510,11 @@ _do_build()
     ERL_TOP="$KERL_BUILD_DIR/$2/otp_src_$1"
     cd "$ERL_TOP" || exit 1
     LOGFILE="$KERL_BUILD_DIR/$2/otp_build_$1.log"
+    # Don't apply patches to "custom" git builds. We have no idea if they will apply
+    # cleanly or not.
+    if [ "$1" != "git" ]; then
+        maybe_patch "$KERL_SYSTEM" "$1"
+    fi
     if [ -n "$KERL_USE_AUTOCONF" ]; then
         ./otp_build autoconf $KERL_CONFIGURE_OPTIONS > "$LOGFILE" 2>&1 && \
             ./otp_build configure $KERL_CONFIGURE_OPTIONS >> "$LOGFILE" 2>&1

--- a/kerl
+++ b/kerl
@@ -370,6 +370,12 @@ get_otp_version()
     echo $1 | sed $SED_OPT -e 's/R?([0-9]{1,2})[.AB]?[-.0-9rc]*/\1/'
 }
 
+get_javac_version()
+{
+    javaout=$(javac -version 2>&1)
+    echo "$javaout" | cut -d' ' -f2 | cut -d'.' -f2
+}
+
 show_logfile()
 {
     echo "$1"
@@ -383,30 +389,45 @@ maybe_patch()
     # $1 = OS platform e.g., Darwin, etc
     # $2 = OTP release
 
+    release=$(get_otp_version "$2")
     case "$1" in
         Darwin)
-            maybe_patch_darwin "$2"
+            maybe_patch_darwin "$release"
             ;;
         SunOS)
-            maybe_patch_sunos "$2"
+            maybe_patch_sunos "$release"
             ;;
         *)
             ;;
     esac
+
+    maybe_patch_all "$release"
+}
+
+maybe_patch_all()
+{
+    # Are we building docs?
+    if [ "$KERL_BUILD_DOCS" ]; then
+        if [ "$1" -le 16 ]; then
+            javaver=$(get_javac_version)
+            if [ "$javaver" -ge 8 ]; then
+                apply_javadoc_linting_patch >> "$LOGFILE"
+            fi
+        fi
+    fi
 }
 
 maybe_patch_darwin()
 {
-    release=$(get_otp_version "$1")
-    if [ "$release" -le 14 ]; then
-        apply_darwin_patch >> "$LOGFILE"
+    if [ "$1" -le 14 ]; then
+        CFLAGS="-DERTS_DO_INCL_GLB_INLINE_FUNC_DEF"
+        apply_darwin_compiler_patch >> "$LOGFILE"
     fi
 }
 
 maybe_patch_sunos()
 {
-    release=$(get_otp_version "$1")
-    if [ "$release" -le 14 ]; then
+    if [ "$1" -le 14 ]; then
         apply_solaris_networking_patch >> "$LOGFILE"
     fi
 }
@@ -482,10 +503,10 @@ _do_build()
         maybe_patch "$KERL_SYSTEM" "$1"
     fi
     if [ -n "$KERL_USE_AUTOCONF" ]; then
-        ./otp_build autoconf $KERL_CONFIGURE_OPTIONS > "$LOGFILE" 2>&1 && \
-            ./otp_build configure $KERL_CONFIGURE_OPTIONS >> "$LOGFILE" 2>&1
+        ./otp_build autoconf $KERL_CONFIGURE_OPTIONS >> "$LOGFILE" 2>&1 && \
+           CFLAGS="$CFLAGS" ./otp_build configure $KERL_CONFIGURE_OPTIONS >> "$LOGFILE" 2>&1
     else
-        ./otp_build configure $KERL_CONFIGURE_OPTIONS > "$LOGFILE" 2>&1
+        CFLAGS="$CFLAGS" ./otp_build configure $KERL_CONFIGURE_OPTIONS >> "$LOGFILE" 2>&1
 
     fi
     if [ $? -ne 0 ]; then
@@ -517,7 +538,7 @@ _do_build()
             fi
         done
     fi
-    ./otp_build boot -a $KERL_CONFIGURE_OPTIONS >> "$LOGFILE" 2>&1
+    CFLAGS="$CFLAGS" ./otp_build boot -a $KERL_CONFIGURE_OPTIONS >> "$LOGFILE" 2>&1
     if [ $? -ne 0 ]; then
         show_logfile "Build failed." "$LOGFILE"
         list_remove builds "$1 $2"
@@ -1070,14 +1091,14 @@ apply_solaris_networking_patch()
 _END_PATCH
 }
 
-apply_darwin_patch()
+apply_darwin_compiler_patch()
 {
     patch -p0 <<_END_PATCH
 --- erts/emulator/beam/beam_bp.c.orig	2011-10-03 13:12:07.000000000 -0500
 +++ erts/emulator/beam/beam_bp.c	2013-10-04 13:42:03.000000000 -0500
 @@ -496,7 +496,8 @@
  }
-
+ 
  /* bp_hash */
 -ERTS_INLINE Uint bp_sched2ix() {
 +#ifndef ERTS_DO_INCL_GLB_INLINE_FUNC_DEF
@@ -1098,7 +1119,7 @@ apply_darwin_patch()
 @@ -144,7 +144,19 @@
  #define ErtsSmpBPUnlock(BDC)
  #endif
-
+ 
 -ERTS_INLINE Uint bp_sched2ix(void);
 +ERTS_GLB_INLINE Uint bp_sched2ix(void);
 +
@@ -1113,9 +1134,29 @@ apply_darwin_patch()
 +#endif
 +}
 +#endif
-
+ 
  #ifdef ERTS_SMP
  #define bp_sched2ix_proc(p) ((p)->scheduler_data->no - 1)
+_END_PATCH
+}
+
+# javadoc 8 includes always-enabled document linting which causes
+# documentation builds to fail on older OTP releases.
+apply_javadoc_linting_patch()
+{
+    # The _END_PATCH token is quoted below to disable parameter substitution
+    patch -p0 <<'_END_PATCH'
+--- lib/jinterface/doc/src/Makefile.orig	2016-05-23 14:34:48.000000000 -0500
++++ lib/jinterface/doc/src/Makefile	2016-05-23 14:35:48.000000000 -0500
+@@ -142,7 +142,7 @@
+ 	rm -f errs core *~
+ 
+ jdoc:$(JAVA_SRC_FILES)
+-	(cd ../../java_src;$(JAVADOC) -sourcepath . -d $(JAVADOC_DEST) \
++	(cd ../../java_src;$(JAVADOC) -Xdoclint:none -sourcepath . -d $(JAVADOC_DEST) \
+ 		-windowtitle $(JAVADOC_TITLE) $(JAVADOC_PKGS))
+ 
+ man: 
 _END_PATCH
 }
 


### PR DESCRIPTION
This PR incorporates code from #18 and addresses #64. The following patches are now inlined into kerl and applied appropriately:

* On OS X since Mavericks (i.e., using clang), when building R14 - fix compiler error
* On Solaris, building R14 - fix networking code
* On any platform with Java 8, building R14 or R15 or R16 - stop linting bad javadoc tags (only applied if kerl is building docs from source)
* On any platform with perl 5.24 building R14 or R15 - fix a fatalized warning while generating beam opcodes

**IMPORTANT**: We do not patch builds from git sources, because there's really no good way to tell if the patches will apply cleanly. (Officially tagged tarballs from OTP github are fine. Some random github repo not so good...)