### PR TITLE
Do not assume writes to list_add/remove succeed

### DIFF
--- a/kerl
+++ b/kerl
@@ -889,16 +889,16 @@ list_add()
                 return 1
             fi
         done < "$KERL_BASE_DIR/otp_$1"
-        echo "$2" >> "$KERL_BASE_DIR/otp_$1"
+        echo "$2" >> "$KERL_BASE_DIR/otp_$1" || exit 1
     else
-        echo "$2" > "$KERL_BASE_DIR/otp_$1"
+        echo "$2" > "$KERL_BASE_DIR/otp_$1" || exit 1
     fi
 }
 
 list_remove()
 {
     if [ -f "$KERL_BASE_DIR/otp_$1" ]; then
-        sed $SED_OPT -i -e "/^.*$2$/d" "$KERL_BASE_DIR/otp_$1"
+        sed $SED_OPT -i -e "/^.*$2$/d" "$KERL_BASE_DIR/otp_$1" || exit 1
     fi
 }
 


### PR DESCRIPTION
If the `otp_builds` or `otp_installations` files in `KERL_BASE_DIR` are unwritable kerl will falsely report a successful action. Now exit from the script with a return code of 1. Addresses #141.