### PR TITLE
fix extraction of files for some versions of tar

### DIFF
--- a/kerl
+++ b/kerl
@@ -469,7 +469,7 @@ do_normal_build()
         # github tarballs have a directory in the form of "otp[_-]TAGNAME"
         # Ericsson tarballs have the classic otp_src_RELEASE pattern
         # Standardize on Ericsson format because that's what the rest of the script expects
-        (cd "$UNTARDIRNAME" && tar xfz "$KERL_DOWNLOAD_DIR/$FILENAME.tar.gz" && mv ./* "$KERL_BUILD_DIR/$2/otp_src_$1")
+        (cd "$UNTARDIRNAME" && tar xzf "$KERL_DOWNLOAD_DIR/$FILENAME.tar.gz" && mv ./* "$KERL_BUILD_DIR/$2/otp_src_$1")
         rm -rf "$UNTARDIRNAME"
     fi
 
@@ -773,7 +773,7 @@ download_manpages()
     FILENAME=otp_doc_man_$1.tar.gz
     tarball_download "$FILENAME"
     echo "Extracting manpages"
-    cd "$absdir" && tar xfz "$KERL_DOWNLOAD_DIR/$FILENAME"
+    cd "$absdir" && tar xzf "$KERL_DOWNLOAD_DIR/$FILENAME"
 }
 
 download_htmldocs()


### PR DESCRIPTION
Some versions of tar complain if  `f` parameter is not the last parameter