### PR TITLE
Add support for customized prompt for activated installations

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,10 @@ You can set the following variables:
 - `KERL_SASL_STARTUP` use SASL system startup instead of minimal
 - `KERL_DEPLOY_SSH_OPTIONS` if additional options are required, e.g. `-qx -o PasswordAuthentication=no`
 - `KERL_DEPLOY_RSYNC_OPTIONS` if additional options are required, e.g. `--delete`
-- `KERL_ENABLE_PROMPT` if set, the prompt will be prefixed with the name of the active build 
+- `KERL_ENABLE_PROMPT` if set, will enable the prompt to be prefixed with what is set in `KERL_PROMPT_FORMAT`.
+- `KERL_PROMPT_FORMAT` the format string to use as a prefix for the prompt. If not set (or empty) will default to `(%BUILDNAME%)`. The following variables are available for use in the format string.
+  - `%RELEASE%` The active release (e.g. `18.0` or `R16B02`)
+  - `%BUILDNAME%` The active buildname (e.g. `my_test_build_18.0`)
 - `KERL_BUILD_DOCS` if set, will build documentation from source code repository
 - `KERL_USE_AUTOCONF` use autoconf in the builds process (**note**: implied by the `git` build backend)
 

--- a/kerl
+++ b/kerl
@@ -665,6 +665,8 @@ kerl_deactivate()
     if [ ! "\$1" = "nondestructive" ]; then
         unset -f kerl_deactivate
     fi
+    unset KERL_ENABLE_PROMPT
+    unset KERL_PROMPT_FORMAT
 }
 kerl_deactivate nondestructive
 
@@ -684,7 +686,13 @@ if [ -f "$KERL_CONFIG" ]; then . "$KERL_CONFIG"; fi
 if [ -n "\$KERL_ENABLE_PROMPT" ]; then
     _KERL_SAVED_PS1="\$PS1"
     export _KERL_SAVED_PS1
-    PS1="($1)\$PS1"
+    if [ -n "\$KERL_PROMPT_FORMAT" ]; then
+        FRMT="\$KERL_PROMPT_FORMAT"
+    else
+        FRMT="(%BUILDNAME%)"
+    fi
+    PROMPT=\$(echo "\$FRMT" | sed 's^%RELEASE%^$rel^;s^%BUILDNAME%^$1^')
+    PS1="\$PROMPT\$PS1"
     export PS1
 fi
 if [ -n "\$BASH" -o -n "\$ZSH_VERSION" ]; then


### PR DESCRIPTION
I wanted to see what release I was using when I forgot to put the name in the build name and I wanted some colors so I ended up implementing this. 

Not sure if this is a "requested feature" but anyway, if you are interested to take it in, here it is :smile: 