### PR TITLE
Fix invalid symlinks when KERL_BUILD_DOCS=true

### DIFF
--- a/kerl
+++ b/kerl
@@ -772,8 +772,7 @@ ACTIVATE_FISH
         DOC_DIR="$KERL_BUILD_DIR/$1/release_$rel/lib/erlang"
         if [ -d "$DOC_DIR" ]; then
             echo "Installing docs..."
-            mkdir -p "$absdir/lib/erlang" || exit 1
-            cp $CP_OPT "$DOC_DIR/" "$absdir/lib/erlang"
+            cp $CP_OPT "$DOC_DIR/" "$absdir/lib"
             ln -s "$absdir/lib/erlang/man" "$absdir/man"
             ln -s "$absdir/lib/erlang/doc" "$absdir/html"
         fi


### PR DESCRIPTION
The previous code incorrectly copied the generated documentation into `$absdir/lib/erlang/erlang`.  This fix places it in `$absdir/lib/erlang` which is the target of the `man` and `html` symlinks.