### PR TITLE
Fix issue #154

### DIFF
--- a/kerl
+++ b/kerl
@@ -696,8 +696,8 @@ if [ -n "\$KERL_ENABLE_PROMPT" ]; then
     else
         FRMT="(%BUILDNAME%)"
     fi
-    PROMPT=\$(echo "\$FRMT" | sed 's^%RELEASE%^$rel^;s^%BUILDNAME%^$1^')
-    PS1="\$PROMPT\$PS1"
+    PRMPT=\$(echo "\$FRMT" | sed 's^%RELEASE%^$rel^;s^%BUILDNAME%^$1^')
+    PS1="\$PRMPT\$PS1"
     export PS1
 fi
 if [ -n "\$BASH" -o -n "\$ZSH_VERSION" ]; then


### PR DESCRIPTION
Apparently zsh doesn't handle the variable PROMPT very well and overwrites PS1 immediately.

Fixing it by changing the temporary variable name