### PR TITLE
Ask homebrew for openssl location if available

### DIFF
--- a/README.md
+++ b/README.md
@@ -448,9 +448,10 @@ own SSL library. That makes using homebrew the most convenient way to install
 openssl on macOS 10.12 (Sierra) or El Capitan. Recently, homebrew [decided to
 stop creating](https://github.com/Homebrew/brew/pull/612) symlinks from the
 homebrew installation directory to `/usr/local`, so in response to this, *if*
-you running El Capitan or Sierra, *and* you have homebrew installed, *and* you
-used it to install openssl, kerl will ask homebrew for the openssl installation
-prefix and configure Erlang to build with that location automatically.
+you're running El Capitan or Sierra, *and* you have homebrew installed, *and*
+you used it to install openssl, kerl will ask homebrew for the openssl
+installation prefix and configure Erlang to build with that location
+automatically.
 
 **Important**: If you already have `--with-ssl` in your .kerlrc, kerl
 will honor that instead, and will not do any automatic configuration.

--- a/README.md
+++ b/README.md
@@ -440,8 +440,24 @@ Prints the available builds and installations as well as the currently active in
     ----------
     No Erlang/OTP kerl installation is currently active
 
+
+Compiling crypto on Macs
+------------------------
+Apple stopped shipping OpenSSL in OS X 10.11 (El Capitan) in favor of Apple's
+own SSL library. That makes using homebrew the most convenient way to install
+openssl on macOS 10.12 (Sierra) or El Capitan. Recently, homebrew [decided to
+stop creating](https://github.com/Homebrew/brew/pull/612) symlinks from the
+homebrew installation directory to `/usr/local`, so in response to this, *if*
+you running El Capitan or Sierra, *and* you have homebrew installed, *and* you
+used it to install openssl, kerl will ask homebrew for the openssl installation
+prefix and configure Erlang to build with that location automatically.
+
+**Important**: If you already have `--with-ssl` in your .kerlrc, kerl
+will honor that instead, and will not do any automatic configuration.
+
 Changelog
 ---------
+
 20 July 2016 - 1.3.2
 
   - Optionally enhance the activation prompt (#149)

--- a/kerl
+++ b/kerl
@@ -515,18 +515,18 @@ _do_build()
                     echo -n $KERL_CONFIGURE_OPTIONS | grep "ssl" 1>/dev/null 2>&1
                     # Reminder to self: 0 from grep means the string was detected
                     if [ $? -ne 0 ]; then
-                        brew_prefix=$(brew --prefix openssl)
-                        if [ -n "$brew_prefix" -a -d "$brew_prefix" ]; then
-                            KERL_CONFIGURE_OPTIONS="$KERL_CONFIGURE_OPTIONS --with-ssl=$brew_prefix"
+                        whichbrew=$(which brew)
+                        if [ -n "$whichbrew" -a -x "$whichbrew" ]; then
+                            brew_prefix=$(brew --prefix openssl)
+                            if [ -n "$brew_prefix" -a -d "$brew_prefix" ]; then
+                                KERL_CONFIGURE_OPTIONS="$KERL_CONFIGURE_OPTIONS --with-ssl=$brew_prefix"
+                            fi
                         elif [ ! -d /usr/include/openssl -o ! -d /usr/local/include/openssl ]; then
                             # Apple removed OpenSSL from El Capitan, but its still in this
                             # funky location, so set ssl headers to look here
                             xc_ssl='/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift-migrator/sdk/MacOSX.sdk/usr'
-                            if [ -d "$xc_ssl/include/openssl" ]
-                            then
+                            if [ -d "$xc_ssl/include/openssl" ]; then
                                 KERL_CONFIGURE_OPTIONS="$KERL_CONFIGURE_OPTIONS --with-ssl=$xc_ssl"
-                            else
-                                echo 'WARNING: No OpenSSL library was found in the usual places. Your Erlang will be built without crypto support!'
                             fi
                             unset xc_ssl
                         fi

--- a/kerl
+++ b/kerl
@@ -508,16 +508,19 @@ _do_build()
 {
     case "$KERL_SYSTEM" in
         Darwin)
-            # Apple removed OpenSSL from El Capitan, but its still in this
-            # funky location, so set ssl headers to look here
             OSVERSION=`uname -r`
             RELVERSION=`get_otp_version "$1"`
             case "$OSVERSION" in
-                15*)
+                16*|15*)
                     echo -n $KERL_CONFIGURE_OPTIONS | grep "ssl" 1>/dev/null 2>&1
                     # Reminder to self: 0 from grep means the string was detected
                     if [ $? -ne 0 ]; then
-                        if [ ! -d /usr/include/openssl -o ! -d /usr/local/include/openssl ]; then
+                        brew_prefix=$(brew --prefix openssl)
+                        if [ -n "$brew_prefix" -a -d "$brew_prefix" ]; then
+                            KERL_CONFIGURE_OPTIONS="$KERL_CONFIGURE_OPTIONS --with-ssl=$brew_prefix"
+                        elif [ ! -d /usr/include/openssl -o ! -d /usr/local/include/openssl ]; then
+                            # Apple removed OpenSSL from El Capitan, but its still in this
+                            # funky location, so set ssl headers to look here
                             xc_ssl='/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift-migrator/sdk/MacOSX.sdk/usr'
                             if [ -d "$xc_ssl/include/openssl" ]
                             then
@@ -526,7 +529,7 @@ _do_build()
                                 echo 'WARNING: No OpenSSL library was found in the usual places. Your Erlang will be built without crypto support!'
                             fi
                             unset xc_ssl
-                         fi
+                        fi
                      fi
                 ;;
                 *)


### PR DESCRIPTION
If we're building Erlang on { OS X | macOS } of recent vintage, *and* homebrew is installed *and* openssl was installed, ask homebrew where openssl is located and configure OTP to build with that path.