### PR TITLE
Clean and re-run configure when --enable-native-libs is used

### DIFF
--- a/kerl
+++ b/kerl
@@ -556,6 +556,11 @@ _do_build()
         CFLAGS="$CFLAGS" ./otp_build configure $KERL_CONFIGURE_OPTIONS >> "$LOGFILE" 2>&1
 
     fi
+    echo -n $KERL_CONFIGURE_OPTIONS | grep "--enable-native-libs" 1>/dev/null 2>&1
+    if [ $? -ne 0 ]; then
+        make clean >> "$LOGFILE" 2>&1
+        CFLAGS="$CFLAGS" ./otp_build configure $KERL_CONFIGURE_OPTIONS >> "$LOGFILE" 2>&1
+    fi
     if [ $? -ne 0 ]; then
         show_logfile "Configure failed." "$LOGFILE"
         list_remove builds "$1 $2"


### PR DESCRIPTION
The OTP repository contains pre-built BEAM files that will not get
recompiled natively unless "make clean" is called first. This
commit detects when the --enable-native-libs option is used
and runs the appropriate commands.

Depending on the source of the code, this will result in the
configure step being run twice, as a Makefile is needed before
we can do "make clean". Configure will be run once otherwise.

Fix for https://github.com/kerl/kerl/issues/68

I have tested it against "kerl build git", and "kerl build" with backends tarball and git. I have also tried with/without native libs. Not sure I covered all cases though.

To check if the code has been properly compiled natively, try running "code:is_module_native(lists)." in a shell of the release you built.