### PR TITLE
Use a more portable way to put PATH back to normal

### DIFF
--- a/kerl
+++ b/kerl
@@ -650,12 +650,12 @@ do_install()
 kerl_deactivate()
 {
     if [ -n "\$_KERL_PATH_REMOVABLE" ]; then
-        PATH=\${PATH//\${_KERL_PATH_REMOVABLE}:/}
+        PATH=\`echo \${PATH} | sed -e "s#\${_KERL_PATH_REMOVABLE}:##"\`
         export PATH
         unset _KERL_PATH_REMOVABLE
     fi
     if [ -n "\$_KERL_MANPATH_REMOVABLE" ]; then
-        MANPATH=\${MANPATH//\${_KERL_MANPATH_REMOVABLE}:/}
+        MANPATH=\`echo \${MANPATH} | sed -e "s#\${_KERL_MANPATH_REMOVABLE}:##"\`
         export MANPATH
         unset _KERL_MANPATH_REMOVABLE
     fi


### PR DESCRIPTION
Fix for #164 (and probably #93).

Works for me on FreeBSD 10.1 and Arch Linux more or less current. No OSX to try right now.

Only `kerl install` is needed to test the changes so it should be quick to test on various other platforms, assuming a build already exists.