### PR TITLE
Assert perl exists before builds (#170)

### DIFF
--- a/kerl
+++ b/kerl
@@ -382,13 +382,35 @@ get_otp_version()
 
 get_perl_version()
 {
-    perl -v | grep version | sed $SED_OPT -e 's/.*v5\.([0-9]+)\.[0-9].*/\1/'
+    if assert_perl; then
+        perl -v | grep version | sed $SED_OPT -e 's/.*v5\.([0-9]+)\.[0-9].*/\1/'
+    else
+        echo "FATAL: I couldn't find perl which is required to compile Erlang."
+        exit 1
+    fi
+}
+
+assert_perl()
+{
+    perl_loc=$(which perl)
+    if [ -z "$perl_loc" ]; then
+        return 1
+    else
+        # 0 to bash is "true" because of Unix exit code conventions
+        return 0
+    fi
 }
 
 get_javac_version()
 {
-    javaout=$(javac -version 2>&1)
-    echo "$javaout" | cut -d' ' -f2 | cut -d'.' -f2
+    java_loc=$(which javac)
+    if [ -z "$java_loc" ]; then
+        # Java's not installed, so just return 0
+        0
+    else
+        javaout=$(javac -version 2>&1)
+        echo "$javaout" | cut -d' ' -f2 | cut -d'.' -f2
+    fi
 }
 
 show_configuration_warnings()


### PR DESCRIPTION
Perl 5 is required to compile Erlang from source. It's used (among other things) to assemble BEAM opcodes, NIF jump tables and more. We now assert perl exists on the PATH before we proceed to build Erlang or test for Perl's version string.

We also now test for Java before we try to find its version. Java is not required to compile Erlang though, so we don't output any warnings or errors if its not found. 

This PR addresses #170 and supersedes #173 