### PR TITLE
Store build configuration in a file

### DIFF
--- a/kerl
+++ b/kerl
@@ -931,7 +931,7 @@ build_plt()
 
 do_plt()
 {
-    ACTIVE_PATH=`get_active_path`
+    ACTIVE_PATH="$1"
     if [ -n "$ACTIVE_PATH" ]; then
         plt=$ACTIVE_PATH/dialyzer/plt
         if [ -f "$plt" ]; then
@@ -945,6 +945,19 @@ do_plt()
     else
         echo "No Erlang/OTP kerl installation is currently active"
         return 2
+    fi
+}
+
+print_buildopts()
+{
+    buildopts="$1/$KERL_CONFIG_STORAGE_FILENAME"
+    if [ -f "$buildopts" ]; then
+        echo "The build options for the active installation are:"
+        cat "$buildopts"
+        return 0
+    else
+        echo "The build options for the active installation are not available."
+        return 1
     fi
 }
 
@@ -1545,7 +1558,7 @@ case "$1" in
         fi
         ;;
     plt)
-        if ! do_plt; then
+        if ! do_plt get_active_path; then
             exit 1;
         fi
         ;;
@@ -1557,7 +1570,14 @@ case "$1" in
         list_print installations
         echo "----------"
         if do_active; then
-            do_plt
+            ACTIVE_PATH=`get_active_path`
+            if [ -n "$ACTIVE_PATH" ]; then
+                do_plt "$ACTIVE_PATH"
+                print_buildopts "$ACTIVE_PATH"
+            else
+                echo "No Erlang/OTP installation is currently active."
+                exit 1
+            fi
         fi
         exit 0
         ;;

--- a/kerl
+++ b/kerl
@@ -30,6 +30,7 @@ KERL_VERSION="1.3.4"
 GREP_OPTIONS=''
 
 ERLANG_DOWNLOAD_URL="http://www.erlang.org/download"
+KERL_CONFIG_STORAGE_FILENAME=".kerl_config"
 
 if [ -z "$HOME" ]; then
     echo "Error: \$HOME is empty or not set." 1>&2
@@ -549,6 +550,31 @@ _do_build()
     ERL_TOP="$KERL_BUILD_DIR/$2/otp_src_$1"
     cd "$ERL_TOP" || exit 1
     LOGFILE="$KERL_BUILD_DIR/$2/otp_build_$1.log"
+
+    # Check to see if configuration options need to be stored or have changed
+    TMPOPT="/tmp/kerloptions.$$"
+    echo "$CFLAGS" > "$TMPOPT"
+    echo "$KERL_CONFIGURE_OPTIONS" >> "$TMPOPT"
+    SUM=$($MD5SUM "$TMPOPT" | cut -d ' ' -f $MD5SUM_FIELD)
+    # Check for a .kerl_config.md5 file
+    if [ -e "./$KERL_CONFIG_STORAGE_FILENAME.md5" ]; then
+        # Compare our current options to the saved ones
+        OLD_SUM=read -r < "./$KERL_CONFIG_STORAGE_FILENAME.md5"
+        if [ "$SUM" -ne "$OLD_SUM" ]; then
+            echo "Configure options have changed. Reconfiguring..."
+            rm -f configure
+            mv "$TMPOPT" "./$KERL_CONFIG_STORAGE_FILENAME"
+            echo "$SUM" > "./$KERL_CONFIG_STORAGE_FILENAME.md5"
+        else
+            # configure options are the same
+            rm -f "$TMPOPT"
+        fi
+    else
+	# no file exists, so write one
+	mv "$TMPOPT" ./.kerl_config
+	echo "$SUM" > ./.kerl_config.md5
+    fi
+
     # Don't apply patches to "custom" git builds. We have no idea if they will apply
     # cleanly or not.
     if [ "$1" != "git" ]; then
@@ -598,6 +624,7 @@ _do_build()
             fi
         done
     fi
+
     CFLAGS="$CFLAGS" ./otp_build boot -a $KERL_CONFIGURE_OPTIONS >> "$LOGFILE" 2>&1
     if [ $? -ne 0 ]; then
         show_logfile "Build failed." "$LOGFILE"
@@ -851,6 +878,9 @@ ACTIVATE_CSH
             fi
         fi
     fi
+
+    KERL_CONFIG_STORAGE_PATH="$KERL_BUILD_DIR/$1/otp_src_$rel/$KERL_CONFIG_STORAGE_FILENAME"
+    [ -e "$KERL_CONFIG_STORAGE_PATH" ] && cp "$KERL_CONFIG_STORAGE_PATH" "$absdir/$KERL_CONFIG_STORAGE_FILENAME"
 
     if [ -n "$KERL_BUILD_PLT" ]; then
         echo "Building Dialyzer PLT..."


### PR DESCRIPTION
This change implements storing the build configuration in a file which can later be compared to a potentially new configuration which might trigger the need to re-run the OTP configuration steps.

We also copy the build configuration into the installation directory so that at some future time we can write or enhance a command which shows the build configuration.

Addresses #162 #158

**Note**: Still need to implement any output commands