### PR TITLE
Add `kerl path` command

### DIFF
--- a/bash_completion/kerl
+++ b/bash_completion/kerl
@@ -12,7 +12,7 @@ _kerl()
 
     case $prev in
         kerl)
-            COMPREPLY=( $( compgen -W "build install update list delete active status" -- "$cur" ) )
+            COMPREPLY=( $( compgen -W "build install update list delete active path status" -- "$cur" ) )
             ;;
         list)
             COMPREPLY=( $( compgen -W "releases builds installations" -- "$cur" ) )
@@ -41,6 +41,13 @@ _kerl()
                 BUILDS=$(cut -d ',' -f 2 "$HOME"/.kerl/otp_builds)
             fi
             COMPREPLY=( $( compgen -W "$BUILDS" -- "$cur") )
+            ;;
+         path)
+            INSTALL_LIST="$HOME"/.kerl/otp_installations
+            if [ -f "$INSTALL_LIST" ]; then
+                NAMES=$(cut -d ' ' -f 2 "$INSTALL_LIST" | xargs basename)
+            fi
+            COMPREPLY=( $( compgen -W "$NAMES" -- "$cur") )
             ;;
          deploy)
             if [ "$COMP_CWORD" -eq 3 ]; then

--- a/kerl
+++ b/kerl
@@ -171,7 +171,7 @@ usage()
 {
     echo "kerl: build and install Erlang/OTP"
     echo "usage: $0 <command> [options ...]"
-    printf "\n  <command>       Command to be executed\n\n"
+    echo "\n  <command>       Command to be executed\n\n"
     echo "Valid commands are:"
     echo "  build    Build specified release or git repository"
     echo "  install  Install the specified release at the given location"
@@ -1200,6 +1200,24 @@ list_print()
     echo "There are no $1 available"
 }
 
+list_print1()
+{
+    # TODO Assert that there is exactly 1 match
+    # TODO This function is a misnomer because it's becoming
+    # totally specialised to finding an installation by name
+    # We really only want to match if a single install has a path
+    # such that $(basename $installpath) == $2
+    # There are some possible extensions to this we could
+    # consider, such as:
+    # - match as above if there's exactly 1 match
+    # - if 2+ matches: prefer one in a subdir from $PWD
+    # - prefer $KERL_DEFAULT_INSTALL_DIR
+    # - probably more!
+    # FIXME 'grep -w' treats '-' as word boundary, so a search for
+    # 'foo-1' will match both '/path/foo-1' and '/path/bar-foo-1'
+    grep -w "$2" "$KERL_BASE_DIR/otp_$1" 2>&1
+}
+
 list_add()
 {
     if [ -f "$KERL_BASE_DIR/otp_$1" ]; then
@@ -1561,7 +1579,19 @@ case "$1" in
         # kerl path <install>
         # Print path to installation with name <install>, else non-zero exit
         if [ -z "$2" ]; then
-            get_active_path
+            # TODO Print a warning if no active path
+            activepath=$(get_active_path)
+            if [ -z "$activepath" ]; then
+                echo "No active kerl-managed erlang installation"
+                exit 1
+            fi
+            echo "$activepath"
+        else
+            # TODO Move this inside something like assert_valid_installation
+            # that either prints exactly 1 match or exits non-zero
+            # TODO Print exactly 1 otherwise error
+            activepath=$(list_print1 installations "$2" | cut -d' ' -f2)
+            echo $activepath
         fi
         ;;
     delete)

--- a/kerl
+++ b/kerl
@@ -1229,6 +1229,11 @@ list_has()
     return 1
 }
 
+path_usage()
+{
+    echo "usage: $0 path [<install_name>]"
+}
+
 list_usage()
 {
     echo "usage: $0 list <releases|builds|installations>"
@@ -1548,6 +1553,16 @@ case "$1" in
                 exit 1
                 ;;
         esac
+        ;;
+    path)
+        # Usage:
+        # kerl path
+        # # Print currently active installation path, else non-zero exit
+        # kerl path <install>
+        # Print path to installation with name <install>, else non-zero exit
+        if [ -z "$2" ]; then
+            get_active_path
+        fi
         ;;
     delete)
         if [ $# -ne 3 ]; then

--- a/kerl
+++ b/kerl
@@ -1200,24 +1200,6 @@ list_print()
     echo "There are no $1 available"
 }
 
-list_print1()
-{
-    # TODO Assert that there is exactly 1 match
-    # TODO This function is a misnomer because it's becoming
-    # totally specialised to finding an installation by name
-    # We really only want to match if a single install has a path
-    # such that $(basename $installpath) == $2
-    # There are some possible extensions to this we could
-    # consider, such as:
-    # - match as above if there's exactly 1 match
-    # - if 2+ matches: prefer one in a subdir from $PWD
-    # - prefer $KERL_DEFAULT_INSTALL_DIR
-    # - probably more!
-    # FIXME 'grep -w' treats '-' as word boundary, so a search for
-    # 'foo-1' will match both '/path/foo-1' and '/path/bar-foo-1'
-    grep -w "$2" "$KERL_BASE_DIR/otp_$1" 2>&1
-}
-
 list_add()
 {
     if [ -f "$KERL_BASE_DIR/otp_$1" ]; then
@@ -1579,7 +1561,6 @@ case "$1" in
         # kerl path <install>
         # Print path to installation with name <install>, else non-zero exit
         if [ -z "$2" ]; then
-            # TODO Print a warning if no active path
             activepath=$(get_active_path)
             if [ -z "$activepath" ]; then
                 echo "No active kerl-managed erlang installation"
@@ -1587,11 +1568,23 @@ case "$1" in
             fi
             echo "$activepath"
         else
-            # TODO Move this inside something like assert_valid_installation
-            # that either prints exactly 1 match or exits non-zero
-            # TODO Print exactly 1 otherwise error
-            activepath=$(list_print1 installations "$2" | cut -d' ' -f2)
-            echo $activepath
+            # There are some possible extensions to this we could
+            # consider, such as:
+            # - if 2+ matches: prefer one in a subdir from $PWD
+            # - prefer $KERL_DEFAULT_INSTALL_DIR
+            match=
+            for ins in $(list_print installations | cut -d' ' -f2); do
+                if [ "$(basename $ins)" = "$2" ]; then
+                    if [ -z "$match" ]; then
+                        match="$ins"
+                    else
+                        echo "Error: too many matching installations" >&2
+                        exit 2
+                    fi
+                fi
+            done
+            [ -n "$match" ] && echo "$match" && exit 0
+            echo "Error: no matching installation found" >&2 && exit 1
         fi
         ;;
     delete)

--- a/zsh_completion/_kerl
+++ b/zsh_completion/_kerl
@@ -30,6 +30,10 @@ _kerl_installations() {
   installations=(${(f)"$(_call_program installations kerl list installations 2>/dev/null | cut -f 2 -d " ")"})
 }
 
+_kerl_installnames() {
+    installnames=(${(f)"$(_call_program installations kerl list installations 2>/dev/null | cut -f 2 -d " " | xargs basename)"})
+}
+
 local -a _1st_arguments
 _1st_arguments=(
   'build:Build specified release or git repository'
@@ -39,6 +43,7 @@ _1st_arguments=(
   'list:List releases, builds and installations'
   'delete:Delete builds and installations'
   'active:Print the path of the active installation'
+  'path:Print the path of any installation'
   'status:Print available builds and installations'
   'prompt:Print a string suitable for insertion in prompt'
   'cleanup:Remove compilation artifacts (use after installation)'
@@ -95,6 +100,15 @@ case "$words[1]" in
       fi
       # TODO: suggest starting location of "$KERLDIR/$(lowercase $build)"
       _directories
+      ;;
+  path)
+      _arguments \
+          '1: :->installnames' && return 0
+      if [[ "$state" == installnames ]]; then
+          _kerl_installnames
+          _wanted installnames expl '' compadd -a installnames
+          return
+      fi
       ;;
   deploy) 
       _arguments \


### PR DESCRIPTION
Adds the `kerl path [install-name]` subcommand.

~TODO~:
 - [x] zsh completion
 - [x] bash completion

Usage:

```
0 $ kerl_deactivate
0 $ kerl active
No Erlang/OTP kerl installation is currently active
1 $ kerl path
No active kerl-managed erlang installation
1 $ source kerl/19.2/activate
0 $ kerl path
/Users/sanmiguel/kerl/19.2
0 $ kerl list installations
R16B02_basho10 /Users/sanmiguel/kerl/R16B02_basho10
19.2 /Users/sanmiguel/kerl/19.2
19.2.2 /Users/sanmiguel/kerl/19.2.2
19.2.2 /Users/sanmiguel/kerl/19.2.2-plt
19.2.3 /Users/sanmiguel/kerl/19.2.3
build-plt-19.2 /Users/sanmiguel/kerl/build-plt-19.2-1
0 $ kerl path 19.2
/Users/sanmiguel/kerl/19.2
0 $ kerl path 19.2.2
/Users/sanmiguel/kerl/19.2.2
0 $ kerl path 19.2.2-plt
/Users/sanmiguel/kerl/19.2.2-plt
0 $ kerl path plt
Error: no matching installation found
1 $
```