### PR TITLE
Apply makeop patch for perls >= 5.22

### DIFF
--- a/kerl
+++ b/kerl
@@ -472,7 +472,7 @@ maybe_patch()
 maybe_patch_all()
 {
     perlver=$(get_perl_version)
-    if [ "$perlver" -ge 24 ]; then
+    if [ "$perlver" -ge 22 ]; then
         case "$1" in
             14)
                 apply_r14_beam_makeops_patch >> "$LOGFILE"


### PR DESCRIPTION
Addresses #197 

Perls >= 5.22 need to have the makeop patch applied when they are building older OTPs.