### PR TITLE
Add a force flag for some mv

### DIFF
--- a/kerl
+++ b/kerl
@@ -526,7 +526,7 @@ do_normal_build()
         # github tarballs have a directory in the form of "otp[_-]TAGNAME"
         # Ericsson tarballs have the classic otp_src_RELEASE pattern
         # Standardize on Ericsson format because that's what the rest of the script expects
-        (cd "$UNTARDIRNAME" && tar xzf "$KERL_DOWNLOAD_DIR/$FILENAME.tar.gz" && mv ./* "$KERL_BUILD_DIR/$2/otp_src_$1")
+        (cd "$UNTARDIRNAME" && tar xzf "$KERL_DOWNLOAD_DIR/$FILENAME.tar.gz" && mv -f ./* "$KERL_BUILD_DIR/$2/otp_src_$1")
         rm -rf "$UNTARDIRNAME"
     fi
 

--- a/kerl
+++ b/kerl
@@ -472,7 +472,7 @@ maybe_patch()
 maybe_patch_all()
 {
     perlver=$(get_perl_version)
-    if [ "$perlver" -ge 24 ]; then
+    if [ "$perlver" -ge 22 ]; then
         case "$1" in
             14)
                 apply_r14_beam_makeops_patch >> "$LOGFILE"


### PR DESCRIPTION
When I was testing `kerl` on [WSL](https://msdn.microsoft.com/en-us/commandline/wsl/about) which uses Ubuntu 16 I noticed that I got an error message when kerl tried to move the unpacked source code tarball into the old build directory.

Need to make sure this works across Macs and Linux before we commit it though. My OS X laptop supports the `-f` flag on mv according to the man page but I haven't tested it yet.