### PR TITLE
Get perl version in a more portable way

### DIFF
--- a/kerl
+++ b/kerl
@@ -391,7 +391,8 @@ get_otp_version()
 get_perl_version()
 {
     if assert_perl; then
-        perl -v | grep version | sed $SED_OPT -e 's/.*v5\.([0-9]+)\.[0-9].*/\1/'
+        # This is really evil but it's portable and it works. Don't @ me bro
+        perl -e 'print int(($] - 5)*1000)'
     else
         echo "FATAL: I couldn't find perl which is required to compile Erlang."
         exit 1


### PR DESCRIPTION
This is a more portable way than regex to extract a perl minor version release number. 

Intended to address #203.

P.S. I feel shame for this "fix" but it works great.