### PR TITLE
Conditionally switch where docs symlink to

### DIFF
--- a/kerl
+++ b/kerl
@@ -889,8 +889,13 @@ ACTIVATE_CSH
         if [ -d "$DOC_DIR" ]; then
             echo "Installing docs..."
             cp $CP_OPT "$DOC_DIR/" "$absdir/lib"
-            ln -s "$absdir/lib/erlang/man" "$absdir/man"
-            ln -s "$absdir/lib/erlang/doc" "$absdir/html"
+            if [ -d "$absdir/lib/erlang/man" ]; then
+                ln -s "$absdir/lib/erlang/man" "$absdir/man"
+                ln -s "$absdir/lib/erlang/doc" "$absdir/html"
+            elif [ -d "$absdir/lib/man" ]; then
+                ln -s "$absdir/lib/man" "$absdir/man"
+                ln -s "$absdir/lib/doc" "$absdir/html"
+            fi
         fi
     else
         if [ "$KERL_BUILD_BACKEND" = "tarball" ]; then


### PR DESCRIPTION
In some cases the docs are built without the 'erlang' subdir.
Fixes #193