### PR TITLE
Remove spurious spaces around KERL_CONFIGURE_OPTIONS line

### DIFF
--- a/kerl
+++ b/kerl
@@ -549,7 +549,7 @@ _do_build()
             # macOS has been mandatory 64 bit for a while
             echo -n $KERL_CONFIGURE_OPTIONS | grep "darwin-64bit" 1>/dev/null 2>&1
             if [ $? -ne 0 ]; then
-                KERL_CONFIGURE_OPTIONS = "$KERL_CONFIGURE_OPTIONS --enable-darwin-64bit"
+                KERL_CONFIGURE_OPTIONS="$KERL_CONFIGURE_OPTIONS --enable-darwin-64bit"
             fi
 
             case "$OSVERSION" in


### PR DESCRIPTION
- extra spaces were causing the line to error:
  /usr/local/bin/kerl: line 552: KERL_CONFIGURE_OPTIONS: command not found