### PR TITLE
Add automatic shell history environment flag for OTP >= 20

### DIFF
--- a/kerl
+++ b/kerl
@@ -768,6 +768,12 @@ REBAR_PLT_DIR="$absdir"
 export REBAR_PLT_DIR
 _KERL_ACTIVE_DIR="$absdir"
 export _KERL_ACTIVE_DIR
+# https://twitter.com/mononcqc/status/877544929496629248
+export _KERL_SAVED_ERL_AFLAGS=" \$ERL_AFLAGS"
+kernel_history=\$(echo "\$ERL_AFLAGS" | grep "kernel shell_history")
+if [ -z "\$kernel_history" ]; then
+    export ERL_AFLAGS="-kernel shell_history enabled \$ERL_AFLAGS"
+fi
 if [ -f "$KERL_CONFIG" ]; then . "$KERL_CONFIG"; fi
 if [ -n "\$KERL_ENABLE_PROMPT" ]; then
     _KERL_SAVED_PS1="\$PS1"
@@ -899,19 +905,6 @@ endif
 
 rehash
 ACTIVATE_CSH
-
-    otpver=$(get_otp_version "$rel")
-    if [ $otpver -ge 20 ]; then
-        # https://twitter.com/mononcqc/status/877544929496629248
-        cat << OTP_20_ADDITION >> "$absdir/activate"
-_KERL_SAVED_ERL_AFLAGS=" \$ERL_AFLAGS"
-export _KERL_SAVED_ERL_AFLAGS
-kernel_history=\$(echo "\$ERL_AFLAGS" | grep "kernel shell_history")
-if [ -z "\$kernel_history" ]; then
-    export ERL_AFLAGS="-kernel shell_history enabled \$ERL_AFLAGS"
-fi
-OTP_20_ADDITION
-    fi
 
     if [ -n "$KERL_BUILD_DOCS" ]; then
         DOC_DIR="$KERL_BUILD_DIR/$1/release_$rel/lib/erlang"

--- a/kerl
+++ b/kerl
@@ -717,6 +717,11 @@ do_install()
 # credits to virtualenv
 kerl_deactivate()
 {
+    if [ -n "\$_KERL_SAVED_ERL_AFLAGS" ]; then
+        ERL_AFLAGS="\$_KERL_SAVED_ERL_AFLAGS"
+        export ERL_AFLAGS
+        unset _KERL_SAVED_ERL_AFLAGS
+    fi
     if [ -n "\$_KERL_PATH_REMOVABLE" ]; then
         PATH=\`echo \${PATH} | sed -e "s#\${_KERL_PATH_REMOVABLE}:##"\`
         export PATH
@@ -894,6 +899,17 @@ endif
 
 rehash
 ACTIVATE_CSH
+
+    otpver=$(get_otp_version "$rel")
+    if [ $otpver -ge 20 ]; then
+        # https://twitter.com/mononcqc/status/877544929496629248
+        cat << OTP_20_ADDITION >> "$absdir/activate"
+_KERL_SAVED_ERL_AFLAGS="\$ERL_AFLAGS"
+export _KERL_SAVED_ERL_AFLAGS
+export ERL_AFLAGS="-kernel shell_history_enabled \$ERL_AFLAGS"
+OTP_20_ADDITION
+    fi
+
     if [ -n "$KERL_BUILD_DOCS" ]; then
         DOC_DIR="$KERL_BUILD_DIR/$1/release_$rel/lib/erlang"
         if [ -d "$DOC_DIR" ]; then

--- a/kerl
+++ b/kerl
@@ -906,7 +906,7 @@ ACTIVATE_CSH
         cat << OTP_20_ADDITION >> "$absdir/activate"
 _KERL_SAVED_ERL_AFLAGS="\$ERL_AFLAGS"
 export _KERL_SAVED_ERL_AFLAGS
-export ERL_AFLAGS="-kernel shell_history_enabled \$ERL_AFLAGS"
+export ERL_AFLAGS="-kernel shell_history enabled \$ERL_AFLAGS"
 OTP_20_ADDITION
     fi
 

--- a/kerl
+++ b/kerl
@@ -904,9 +904,12 @@ ACTIVATE_CSH
     if [ $otpver -ge 20 ]; then
         # https://twitter.com/mononcqc/status/877544929496629248
         cat << OTP_20_ADDITION >> "$absdir/activate"
-_KERL_SAVED_ERL_AFLAGS="\$ERL_AFLAGS"
+_KERL_SAVED_ERL_AFLAGS=" \$ERL_AFLAGS"
 export _KERL_SAVED_ERL_AFLAGS
-export ERL_AFLAGS="-kernel shell_history enabled \$ERL_AFLAGS"
+kernel_history=\$(echo "\$ERL_AFLAGS" | grep "kernel shell_history")
+if [ -z "\$kernel_history" ]; then
+    export ERL_AFLAGS="-kernel shell_history enabled \$ERL_AFLAGS"
+fi
 OTP_20_ADDITION
     fi
 


### PR DESCRIPTION
Based on a [tweet][1] from @ferd, add automatic shell history for OTP >= 20. Only works for bash/zsh currently. Probably want fish shell support and t/csh support too?  Or maybe we should think about a different way to include this feature.

[1]: https://twitter.com/mononcqc/status/877544929496629248