### PR TITLE
suggest the correct activate script based on parent process command

### DIFF
--- a/kerl
+++ b/kerl
@@ -933,8 +933,8 @@ ACTIVATE_CSH
     fi
 
     PID=$$
-    PPID=$(ps -p $PID -o ppid | grep -E "[0-9]+" -o)
-    PARENT_CMD=$(ps -p $PPID -o comm | tail -n 1)
+    PARENT_PID=$(ps -p $PID -o ppid | grep -E "[0-9]+" -o)
+    PARENT_CMD=$(ps -p $PARENT_PID -o ucomm | tail -n 1)
     case "$PARENT_CMD" in
         fish)
             SHELL_SUFFIX=".fish"

--- a/kerl
+++ b/kerl
@@ -932,8 +932,23 @@ ACTIVATE_CSH
         build_plt "$absdir"
     fi
 
+    PID=$$
+    PPID=$(ps -p $PID -o ppid | grep -E "[0-9]+" -o)
+    PARENT_CMD=$(ps -p $PPID -o comm | tail -n 1)
+    case "$PARENT_CMD" in
+        fish)
+            SHELL_SUFFIX=".fish"
+            ;;
+        csh)
+            SHELL_SUFFIX=".csh"
+            ;;
+        *)
+            SHELL_SUFFIX=""
+            ;;
+    esac
+
     echo "You can activate this installation running the following command:"
-    echo ". $absdir/activate"
+    echo ". ${absdir}/activate${SHELL_SUFFIX}"
     echo "Later on, you can leave the installation typing:"
     echo "kerl_deactivate"
 }


### PR DESCRIPTION
Looks at parent process command and suggests sourcing the appropriate activate script for fish and csh.

fixes #224