### PR TITLE
Maybe munge LD and DED_LDFLAGS for macOS >= 10.13

### DIFF
--- a/kerl
+++ b/kerl
@@ -538,6 +538,16 @@ do_normal_build()
     list_add builds "$1,$2"
 }
 
+_flags(){
+  host=$(./erts/autoconf/config.guess)
+  DARWIN_VERSION=$(uname -r | sed $SED_OPT -e 's/R?([0-9]{1,2}).+/\1/')
+  if [ "$DARWIN_VERSION" -ge 17 ]; then
+    CFLAGS="$CFLAGS" DED_LD="$CC" DED_LDFLAGS="-m64 -bundle -bundle_loader ${ERL_TOP}/bin/$host/beam.smp" $@
+  else
+    CFLAGS="$CFLAGS" $@
+  fi
+}
+
 _do_build()
 {
     case "$KERL_SYSTEM" in
@@ -552,9 +562,9 @@ _do_build()
             if [ $? -ne 0 ]; then
                 KERL_CONFIGURE_OPTIONS="$KERL_CONFIGURE_OPTIONS --enable-darwin-64bit"
             fi
-
+            
             case "$OSVERSION" in
-                16*|15*)
+                17*|16*|15*)
                     echo -n $KERL_CONFIGURE_OPTIONS | grep "ssl" 1>/dev/null 2>&1
                     # Reminder to self: 0 from grep means the string was detected
                     if [ $? -ne 0 ]; then
@@ -622,15 +632,15 @@ _do_build()
     fi
     if [ -n "$KERL_USE_AUTOCONF" ]; then
         ./otp_build autoconf $KERL_CONFIGURE_OPTIONS >> "$LOGFILE" 2>&1 && \
-           CFLAGS="$CFLAGS" ./otp_build configure $KERL_CONFIGURE_OPTIONS >> "$LOGFILE" 2>&1
+           _flags ./otp_build configure $KERL_CONFIGURE_OPTIONS >> "$LOGFILE" 2>&1
     else
-        CFLAGS="$CFLAGS" ./otp_build configure $KERL_CONFIGURE_OPTIONS >> "$LOGFILE" 2>&1
+        _flags ./otp_build configure $KERL_CONFIGURE_OPTIONS >> "$LOGFILE" 2>&1
 
     fi
     echo -n $KERL_CONFIGURE_OPTIONS | grep "--enable-native-libs" 1>/dev/null 2>&1
     if [ $? -ne 0 ]; then
         make clean >> "$LOGFILE" 2>&1
-        CFLAGS="$CFLAGS" ./otp_build configure $KERL_CONFIGURE_OPTIONS >> "$LOGFILE" 2>&1
+        _flags ./otp_build configure $KERL_CONFIGURE_OPTIONS >> "$LOGFILE" 2>&1
     fi
     if [ $? -ne 0 ]; then
         show_logfile "Configure failed." "$LOGFILE"
@@ -665,7 +675,7 @@ _do_build()
         done
     fi
 
-    CFLAGS="$CFLAGS" ./otp_build boot -a $KERL_CONFIGURE_OPTIONS >> "$LOGFILE" 2>&1
+    _flags ./otp_build boot -a $KERL_CONFIGURE_OPTIONS >> "$LOGFILE" 2>&1
     if [ $? -ne 0 ]; then
         show_logfile "Build failed." "$LOGFILE"
         list_remove builds "$1 $2"

--- a/kerl
+++ b/kerl
@@ -538,14 +538,29 @@ do_normal_build()
     list_add builds "$1,$2"
 }
 
-_flags(){
-  host=$(./erts/autoconf/config.guess)
-  DARWIN_VERSION=$(uname -r | sed $SED_OPT -e 's/R?([0-9]{1,2}).+/\1/')
-  if [ "$DARWIN_VERSION" -ge 17 ]; then
-    CFLAGS="$CFLAGS" DED_LD="clang" CC="clang" DED_LDFLAGS="-m64 -bundle -bundle_loader ${ERL_TOP}/bin/$host/beam.smp" $@
-  else
-    CFLAGS="$CFLAGS" $@
-  fi
+_flags()
+{
+
+    # We need to munge the LD and DED flags for clang 9 shipped with
+    # High Sierra (macOS 10.13)
+    case "$KERL_SYSTEM" in
+        Darwin)
+            osver=$(uname -r)
+            case "$osver" in
+                17*)
+                    host=$(./erts/autoconf/config.guess)
+                    CFLAGS="$CFLAGS" DED_LD="clang" CC="clang" DED_LDFLAGS="-m64 -bundle -bundle_loader ${ERL_TOP}/bin/$host/beam.smp" $@
+                    ;;
+                *)
+                    CFLAGS="$CFLAGS" $@
+                    ;;
+            esac
+            ;;
+        *)
+            CFLAGS="$CFLAGS" $@
+            ;;
+    esac
+
 }
 
 _do_build()
@@ -562,7 +577,7 @@ _do_build()
             if [ $? -ne 0 ]; then
                 KERL_CONFIGURE_OPTIONS="$KERL_CONFIGURE_OPTIONS --enable-darwin-64bit"
             fi
-            
+
             case "$OSVERSION" in
                 17*|16*|15*)
                     echo -n $KERL_CONFIGURE_OPTIONS | grep "ssl" 1>/dev/null 2>&1
@@ -600,7 +615,7 @@ _do_build()
     ERL_TOP="$KERL_BUILD_DIR/$2/otp_src_$1"
     cd "$ERL_TOP" || exit 1
     LOGFILE="$KERL_BUILD_DIR/$2/otp_build_$1.log"
-    
+
     # Check to see if configuration options need to be stored or have changed
     TMPOPT="/tmp/kerloptions.$$"
     echo "$CFLAGS" > "$TMPOPT"

--- a/kerl
+++ b/kerl
@@ -542,7 +542,7 @@ _flags(){
   host=$(./erts/autoconf/config.guess)
   DARWIN_VERSION=$(uname -r | sed $SED_OPT -e 's/R?([0-9]{1,2}).+/\1/')
   if [ "$DARWIN_VERSION" -ge 17 ]; then
-    CFLAGS="$CFLAGS" DED_LD="$CC" DED_LDFLAGS="-m64 -bundle -bundle_loader ${ERL_TOP}/bin/$host/beam.smp" $@
+    CFLAGS="$CFLAGS" DED_LD="clang" CC="clang" DED_LDFLAGS="-m64 -bundle -bundle_loader ${ERL_TOP}/bin/$host/beam.smp" $@
   else
     CFLAGS="$CFLAGS" $@
   fi
@@ -600,7 +600,7 @@ _do_build()
     ERL_TOP="$KERL_BUILD_DIR/$2/otp_src_$1"
     cd "$ERL_TOP" || exit 1
     LOGFILE="$KERL_BUILD_DIR/$2/otp_build_$1.log"
-
+    
     # Check to see if configuration options need to be stored or have changed
     TMPOPT="/tmp/kerloptions.$$"
     echo "$CFLAGS" > "$TMPOPT"


### PR DESCRIPTION
As explained in #230, DED_LDFLAGS must be set correctly for clang 9 to compile various OTP applications correctly including crypto.
    
This patch reworks #230 a little bit so that it's a tiny bit more generalized, in case we run across another situation where this needs to be done for a particular operating system.

Also, technically, there's an unrelated change which expands the SSL library search to os version 17, but we'll let it slide.