### PR TITLE
circleci: add another CI provider for R15 builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,25 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: debian:8
+    environment:
+      - _KERL_VSN: R15B03-1
+      - KERL_CONFIGURE_DISABLE_APPLICATIONS: 'odbc'
+    steps:
+      - run: apt-get update && apt-get upgrade -y
+      - run: apt-get install -y git curl build-essential libncurses-dev libssl-dev
+      - checkout
+      - run: ./kerl update releases
+      - run:
+          command: ./kerl build "$_KERL_VSN" "$_KERL_VSN"
+          no_output_timeout: 45m
+      - run: ./kerl install "$_KERL_VSN" "install_$_KERL_VSN"
+      - run: ./kerl status
+      - run: |
+          set -x
+          source $(./kerl path install_$_KERL_VSN)/activate
+          erl -s crypto -s init stop
+          kerl_deactivate
+      - run: ./kerl delete installation $(./kerl path install_$_KERL_VSN)
+      - run: ./kerl delete build "$_KERL_VSN"

--- a/kerl
+++ b/kerl
@@ -898,7 +898,7 @@ _KERL_ACTIVE_DIR="$absdir"
 export _KERL_ACTIVE_DIR
 # https://twitter.com/mononcqc/status/877544929496629248
 export _KERL_SAVED_ERL_AFLAGS=" \$ERL_AFLAGS"
-kernel_history=\$(echo "\$ERL_AFLAGS" | grep "kernel shell_history")
+kernel_history=\$(echo "\$ERL_AFLAGS" | grep 'kernel shell_history' || true)
 if [ -z "\$kernel_history" ]; then
     export ERL_AFLAGS="-kernel shell_history enabled \$ERL_AFLAGS"
 fi


### PR DESCRIPTION
Follow up of discussion at https://github.com/kerl/kerl/pull/242
CircleCI is very similar to TravisCI in how simple it is to set up & how it is free for open source projects.

Build fails for some reason: https://circleci.com/gh/fenollp/kerl/17
Ideas?

PS: I'll squash when ready.