### PR TITLE
Add upyun download mirror choice

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,14 @@ be either a branch, a tag or a commit id that will be passed to `git checkout`:
     Building Erlang/OTP 19.2_dev from git, please wait...
     Erlang/OTP 19.2_dev from git has been successfully built
 
+Build from upyun
+----------------
+
+Some countries(China) visit erlang.org and github very slowly.
+[UPYUN](https://github.com/upyun) make all `*tar.gz` under the [Erlang/download](http://www.erlang.org/download) mirror to [UPYUN/download](http://erlang.b0.upaiyun.com/download), make download become super fast.
+
+   $ export DOWNLOAD_BACKEND="upyun"
+   $ kerl build 20.1 20.1_test
 
 Tuning
 ------

--- a/kerl
+++ b/kerl
@@ -31,6 +31,7 @@ GREP_OPTIONS=''
 
 DOCSH_GITHUB_URL="https://github.com/erszcz/docsh.git"
 ERLANG_DOWNLOAD_URL="http://www.erlang.org/download"
+UPYUN_DOWNLOAD_URL="http://erlang.b0.upaiyun.com/download"
 KERL_CONFIG_STORAGE_FILENAME=".kerl_config"
 
 if [ -z "$HOME" ]; then
@@ -137,7 +138,6 @@ fi
 if [ -n "$_KBB" ]; then
     KERL_BUILD_BACKEND="$_KBB"
 fi
-
 if [ -z "$KERL_SASL_STARTUP" ]; then
     INSTALL_OPT=-minimal
 else
@@ -149,6 +149,11 @@ if [ -z "$KERL_BUILD_BACKEND" ]; then
 else
     KERL_BUILD_BACKEND="git"
     KERL_USE_AUTOCONF=1
+fi
+if [ -z "$DOWNLOAD_BACKEND" ]; then
+    DOWNLOAD_BACKEND="official"
+else
+    DOWNLOAD_BACKEND="upyun"
 fi
 
 KERL_SYSTEM=$(uname -s)
@@ -1643,7 +1648,11 @@ tarball_download()
 {
     if [ ! -s "$KERL_DOWNLOAD_DIR/$1" ]; then
         echo "Downloading $1 to $KERL_DOWNLOAD_DIR"
-        curl -f -L -o "$KERL_DOWNLOAD_DIR/$1" "$ERLANG_DOWNLOAD_URL/$1" || exit 1
+        if [ "$DOWNLOAD_BACKEND" = "upyun" ]; then
+            curl -f -L -o "$KERL_DOWNLOAD_DIR/$1" "$UPYUN_DOWNLOAD_URL/$1" || exit 1
+        else
+            curl -f -L -o "$KERL_DOWNLOAD_DIR/$1" "$ERLANG_DOWNLOAD_URL/$1" || exit 1
+        fi
         update_checksum_file
     fi
     ensure_checksum_file


### PR DESCRIPTION
Some countries(China) visit erlang.org and github very slowly, the average download speed is only 30k~40k. It makes the installation process very painful.
[UPYUN](https://github.com/upyun) make all resources under the [Erlang/download](http://www.erlang.org/download) mirror to [UPYUN/download](http://erlang.b0.upaiyun.com/download), make download become super fast.

But the mirror has  a little different from erlang.org, this make change ERLANG_DOWNLOAD_URL doesn't work.
erlang.org can visit directory information by 
`curl -f -q -L -s http://erlang.org/download`
but upyun can't visit directory information, but it provide another way for the same result: 
`curl -f -q -L -S http://erlang.b0.upaiyun.com/releases`
Download tar.gz url example: `http://erlang.b0.upaiyun.com/download/otp_src_R16B.tar.gz`

So I only make download *tar.gz from upyun, check MD5 and update releases still from erlang.org, I think this way is more safety.
#### Download from upyun
![image](https://user-images.githubusercontent.com/3116225/33801359-53814490-dd94-11e7-8ef3-061832c8f409.png)
#### Download from erlang.org
![image](https://user-images.githubusercontent.com/3116225/33801558-c304596a-dd99-11e7-84a0-3474991c0518.png)
