### PR TITLE
Add zlib patch to kerl when building between 17-19

### DIFF
--- a/kerl
+++ b/kerl
@@ -1,6 +1,6 @@
 #! /bin/sh
 
-# Copyright (c) 2016 Mark Allen
+# Copyright (c) 2016-2018 Mark Allen
 # Copyright (c) 2011, 2012 Spawngrid, Inc
 # Copyright (c) 2011 Evax Software <contact(at)evax(dot)org>
 #
@@ -562,6 +562,11 @@ maybe_patch_all()
                 apply_javadoc_linting_patch >> "$LOGFILE"
             fi
         fi
+    fi
+
+    # Maybe apply zlib patch
+    if [ "$1" -ge 17 -a "$1" -le 19 ]; then
+        apply_zlib_patch >> "$LOGFILE"
     fi
 }
 
@@ -1841,6 +1846,93 @@ index cc9bcc995..1b1912630 100644
      ptrMap::iterator it;
      it = ptr2ref.find(temp);
      if(it != ptr2ref.end()) {
+_END_PATCH
+}
+
+# https://github.com/erlang/otp/commit/e27119948fc6ab28bea81019720bddaac5b655a7.patch
+apply_zlib_patch()
+{
+
+    patch -p1 <<'_END_PATCH'
+diff --git a/erts/emulator/beam/external.c b/erts/emulator/beam/external.c
+index 656de7c49ad..4491d486837 100644
+--- a/erts/emulator/beam/external.c
++++ b/erts/emulator/beam/external.c
+@@ -1193,6 +1193,7 @@ typedef struct B2TContext_t {
+     } u;
+ } B2TContext;
+ 
++static B2TContext* b2t_export_context(Process*, B2TContext* src);
+ 
+ static uLongf binary2term_uncomp_size(byte* data, Sint size)
+ {
+@@ -1225,7 +1226,7 @@ static uLongf binary2term_uncomp_size(byte* data, Sint size)
+ 
+ static ERTS_INLINE int
+ binary2term_prepare(ErtsBinary2TermState *state, byte *data, Sint data_size,
+-		    B2TContext* ctx)
++		    B2TContext** ctxp, Process* p)
+ {
+     byte *bytes = data;
+     Sint size = data_size;
+@@ -1239,8 +1240,8 @@ binary2term_prepare(ErtsBinary2TermState *state, byte *data, Sint data_size,
+     size--;
+     if (size < 5 || *bytes != COMPRESSED) {
+ 	state->extp = bytes;
+-        if (ctx)
+-	    ctx->state = B2TSizeInit;
++        if (ctxp)
++	    (*ctxp)->state = B2TSizeInit;
+     }
+     else  {
+ 	uLongf dest_len = (Uint32) get_int32(bytes+1);
+@@ -1257,16 +1258,26 @@ binary2term_prepare(ErtsBinary2TermState *state, byte *data, Sint data_size,
+                 return -1;
+ 	    }
+ 	    state->extp = erts_alloc(ERTS_ALC_T_EXT_TERM_DATA, dest_len);
+-            ctx->reds -= dest_len;
++            if (ctxp)
++                (*ctxp)->reds -= dest_len;
+ 	}
+ 	state->exttmp = 1;
+-        if (ctx) {
++        if (ctxp) {
++            /*
++             * Start decompression by exporting trap context
++             * so we don't have to deal with deep-copying z_stream.
++             */
++            B2TContext* ctx = b2t_export_context(p, *ctxp);
++            ASSERT(state = &(*ctxp)->b2ts);
++            state = &ctx->b2ts;
++
+ 	    if (erl_zlib_inflate_start(&ctx->u.uc.stream, bytes, size) != Z_OK)
+ 		return -1;
+ 
+ 	    ctx->u.uc.dbytes = state->extp;
+ 	    ctx->u.uc.dleft = dest_len;
+ 	    ctx->state = B2TUncompressChunk;
++            *ctxp = ctx;
+         }
+ 	else {
+ 	    uLongf dlen = dest_len;
+@@ -1308,7 +1319,7 @@ erts_binary2term_prepare(ErtsBinary2TermState *state, byte *data, Sint data_size
+ {
+     Sint res;
+ 
+-    if (binary2term_prepare(state, data, data_size, NULL) < 0 ||
++    if (binary2term_prepare(state, data, data_size, NULL, NULL) < 0 ||
+         (res=decoded_size(state->extp, state->extp + state->extsize, 0, NULL)) < 0) {
+ 
+         if (state->exttmp)
+@@ -1435,7 +1446,7 @@ static Eterm binary_to_term_int(Process* p, Uint32 flags, Eterm bin, Binary* con
+             if (ctx->aligned_alloc) {
+                 ctx->reds -= bin_size / 8;
+             }
+-            if (binary2term_prepare(&ctx->b2ts, bytes, bin_size, ctx) < 0) {
++            if (binary2term_prepare(&ctx->b2ts, bytes, bin_size, &ctx, p) < 0) {
+ 		ctx->state = B2TBadArg;
+ 	    }
+             break;
 _END_PATCH
 }
 


### PR DESCRIPTION
This is intended to fix #248.

It applies the upstream patch on Linux or MacOS when building an OTP release between 17 and 19. Tested on 17.5.6.9.  Looks like the zlib patch is already applied on some patch levels in 19, so need to test there to see what happens.