### PR TITLE
Install docsh 0.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -621,7 +621,7 @@ other tools to extract to path information.
 
     kerl install-docsh
 
-**Important note**: docsh currently only supports OTP 18 and 19.
+**Important note**: docsh only supports OTP versions 18 and later.
 
 Install `erl` shell documentation access
 extension - [docsh](https://github.com/erszcz/docsh).

--- a/kerl
+++ b/kerl
@@ -1156,12 +1156,12 @@ install_docsh() {
     GIT=$(echo -n $REPO_URL | $MD5SUM | cut -d ' ' -f $MD5SUM_FIELD)
     BUILDNAME=$1
     DOCSH_DIR="$KERL_BUILD_DIR/$BUILDNAME/docsh"
-    DOCSH_REF="0.4.0"
+    DOCSH_REF="0.5.0"
     ACTIVE_PATH=$2
 
     OTP_VERSION=$(get_otp_version $1)
     # This has to be updated with docsh updates
-    DOCSH_SUPPORTED="^1[89]$"
+    DOCSH_SUPPORTED="^1[89]\|20$"
     echo $OTP_VERSION | grep "$DOCSH_SUPPORTED" > /dev/null 2>&1
     if [ $? -ne 0 ]; then
         echo "Erlang/OTP version $OTP_VERSION not supported by docsh (does not match regex $DOCSH_SUPPORTED)"


### PR DESCRIPTION
Major docsh changes since 0.4.0:

- Support Erlang 20 "Dbgi" chunk (01661fa)
- Guess source file location even if src/ has a hierarchical structure (b442346)
- Fix inconsistent lookup times (7149177)
- Expand shell helper documentation (ab3e143)
- Clean up remaining compiler / Dialyzer warnings (60a202f)
- Apply gomoripeti's fix for proplists' doc retrieval (5407e56)
- Describe manual docsh setup (ecf3582)