### PR TITLE
Alpine support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,15 @@
 version: 2
+workflows:
+  version: 2
+  test-workflow:
+    jobs:
+      - debian8_R15B03-1
+      - centos6_20.2
+      - alpine3.7_20.3
+
 jobs:
 
-  build:
+  debian8_R15B03-1:
     docker:
       - image: debian:8
     environment:
@@ -53,9 +61,36 @@ jobs:
       - run: ./kerl delete installation $(./kerl path install_$_KERL_VSN)
       - run: ./kerl delete build "$_KERL_VSN"
 
-workflows:
-  version: 2
-  test-workflow:
-    jobs:
-      - build
-      - centos6_20.2
+  alpine3.7_20.3:
+    docker:
+      - image: alpine:3.7
+    environment:
+      - _KERL_VSN: 20.3
+      - KERL_CONFIGURE_DISABLE_APPLICATIONS: odbc
+      - KERL_BUILD_BACKEND: git
+      - KERL_BUILD_DOCS: 'yes'
+    steps:
+      - run: apk update && apk upgrade
+      - run: |
+          apk add curl ca-certificates \
+                  dpkg-dev dpkg \
+                  gcc g++ libc-dev linux-headers make autoconf ncurses-dev tar \
+                  openssl-dev unixodbc-dev lksctp-tools-dev \
+                  lksctp-tools \
+                  libxslt git
+      - checkout
+      - run: ./kerl update releases
+      - run:
+          command: |
+            export MAKEFLAGS="-j$(getconf _NPROCESSORS_ONLN)"
+            ./kerl build "$_KERL_VSN" "$_KERL_VSN"
+          no_output_timeout: 45m
+      - run: ./kerl install "$_KERL_VSN" "install_$_KERL_VSN"
+      - run: ./kerl status
+      - run: |
+          set -x
+          source $(./kerl path install_$_KERL_VSN)/activate
+          erl -s crypto -s init stop
+          kerl_deactivate
+      - run: ./kerl delete installation $(./kerl path install_$_KERL_VSN)
+      - run: ./kerl delete build "$_KERL_VSN"

--- a/kerl
+++ b/kerl
@@ -1083,21 +1083,26 @@ ACTIVATE_CSH
         build_plt "$absdir"
     fi
 
-    PID=$$
-    PARENT_PID=$(ps -p $PID -o ppid=) || exit 1
-    # shellcheck disable=SC2086
-    PARENT_CMD=$(ps -p $PARENT_PID -o ucomm | tail -n 1)
-    case "$PARENT_CMD" in
-        fish)
-            SHELL_SUFFIX='.fish'
-            ;;
-        csh)
-            SHELL_SUFFIX='.csh'
-            ;;
-        *)
-            SHELL_SUFFIX=''
-            ;;
-    esac
+    if which apk >/dev/null 2>&1; then
+        # Running on Alpine Linux, assuming non-exotic shell
+        SHELL_SUFFIX=''
+    else
+        PID=$$
+        PARENT_PID=$(ps -p $PID -o ppid=) || exit 1
+        # shellcheck disable=SC2086
+        PARENT_CMD=$(ps -p $PARENT_PID -o ucomm | tail -n 1)
+        case "$PARENT_CMD" in
+            fish)
+                SHELL_SUFFIX='.fish'
+                ;;
+            csh)
+                SHELL_SUFFIX='.csh'
+                ;;
+            *)
+                SHELL_SUFFIX=''
+                ;;
+        esac
+    fi
 
     echo 'You can activate this installation running the following command:'
     echo ". $absdir/activate$SHELL_SUFFIX"


### PR DESCRIPTION
`kerl` would fail when `kerl install`ing on Alpine because of Alpine's incomplete support for `ps -p`.

Note that `kerl build` outputs warnings about `dpkg` not being able to find the required/recommended packages. It seems dpkg's index is not built.
I am unsure how to fix that. They are false negatives anyway.