### PR TITLE
Install docsh 0.6.1

### DIFF
--- a/kerl
+++ b/kerl
@@ -1147,7 +1147,7 @@ install_docsh() {
     GIT=$(printf '%s' $REPO_URL | $MD5SUM | cut -d' ' -f $MD5SUM_FIELD)
     BUILDNAME="$1"
     DOCSH_DIR="$KERL_BUILD_DIR/$BUILDNAME/docsh"
-    DOCSH_REF='0.5.0'
+    DOCSH_REF='0.6.1'
     ACTIVE_PATH="$2"
 
     OTP_VERSION=$(get_otp_version "$1")


### PR DESCRIPTION
Version 0.6.0 brings:

- Support for EEP 48 - https://github.com/erszcz/docsh/issues/18
- Rebar3 plugin - https://github.com/erszcz/docsh/commit/d7fadb83dacadb2d2576d83ca5343697021a3d87
- Hex package - https://hex.pm/packages/docsh

Version 0.6.1 carries Rebar3 plugin rename and some documentation changes.