### PR TITLE
Fix Bash completion for Bash 3

### DIFF
--- a/bash_completion/kerl
+++ b/bash_completion/kerl
@@ -12,42 +12,42 @@ _kerl()
 
     case $prev in
         kerl)
-            mapfile -t COMPREPLY < <( compgen -W 'build install update list delete active path status' -- "$cur" )
+            COMPREPLY=($(compgen -W 'build install update list delete active path status' -- "$cur"))
             ;;
         list)
-            mapfile -t COMPREPLY < <( compgen -W 'releases builds installations' -- "$cur" )
+            COMPREPLY=($(compgen -W 'releases builds installations' -- "$cur"))
             ;;
         build)
             if [ "$COMP_CWORD" -eq 2 ]; then
                 if [ -f "$HOME"/.kerl/otp_releases ]; then
                     RELEASES=$(cat "$HOME"/.kerl/otp_releases)
                 fi
-                mapfile -t COMPREPLY < <( compgen -W "git $RELEASES" -- "$cur")
+                COMPREPLY=($(compgen -W "git $RELEASES" -- "$cur"))
             else
                 if [ -f "$HOME"/.kerl/otp_builds ]; then
                     BUILDS=$(cut -d ',' -f 2 "$HOME"/.kerl/otp_builds)
                 fi
-                mapfile -t COMPREPLY < <( compgen -W "$BUILDS" -- "$cur")
+                COMPREPLY=($(compgen -W "$BUILDS" -- "$cur"))
             fi
             ;;
         installation)
             if [ -f "$HOME"/.kerl/otp_installations ]; then
                 PATHS=$(cut -d ' ' -f 2 "$HOME"/.kerl/otp_installations)
             fi
-            mapfile -t COMPREPLY < <( compgen -W "$PATHS" -- "$cur")
+            COMPREPLY=($(compgen -W "$PATHS" -- "$cur"))
             ;;
         install)
             if [ -f "$HOME"/.kerl/otp_builds ]; then
                 BUILDS=$(cut -d ',' -f 2 "$HOME"/.kerl/otp_builds)
             fi
-            mapfile -t COMPREPLY < <( compgen -W "$BUILDS" -- "$cur")
+            COMPREPLY=($(compgen -W "$BUILDS" -- "$cur"))
             ;;
          path)
             INSTALL_LIST="$HOME"/.kerl/otp_installations
             if [ -f "$INSTALL_LIST" ]; then
                 NAMES=$(cut -d ' ' -f 2 "$INSTALL_LIST" | xargs basename)
             fi
-            mapfile -t COMPREPLY < <( compgen -W "$NAMES" -- "$cur")
+            COMPREPLY=($(compgen -W "$NAMES" -- "$cur"))
             ;;
          deploy)
             if [ "$COMP_CWORD" -eq 3 ]; then
@@ -55,13 +55,13 @@ _kerl()
                     PATHS=$(cut -d ' ' -f 2 "$HOME"/.kerl/otp_installations)
                 fi
             fi
-            mapfile -t COMPREPLY < <( compgen -W "$PATHS" -- "$cur")
+            COMPREPLY=($(compgen -W "$PATHS" -- "$cur"))
             ;;
         delete)
-            mapfile -t COMPREPLY < <( compgen -W 'build installation' -- "$cur")
+            COMPREPLY=($(compgen -W 'build installation' -- "$cur"))
             ;;
         update)
-            mapfile -t COMPREPLY < <( compgen -W 'releases' -- "$cur")
+            COMPREPLY=($(compgen -W 'releases' -- "$cur"))
             ;;
         *)
             if [ "$COMP_CWORD" -eq 3 ]; then


### PR DESCRIPTION
Well, since Bash 3 lacks the `readarray` (`mapfile`), kerl's completion does not work - and, unfortunately, Яpple still ships Bash 3 as default shell on macOS.

In this change we directly assign the result of `compgen` to `COMPREPLY` instead of reading the output of `compgen` into a variable.

Tested on:
- 3.2.57(1)-release (macOS default)
- 4.4.23(1)-release (Homebrew)