### PR TITLE
Deploy kerl to pypi and install kerl from pypi

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 *~
+build/
+dist/
+*.egg-info
+.eggs/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: bash
 sudo: false
 os: osx
-
 env:
   global:
   - KERL_BASE_DIR="$TMPDIR"/.kerl
@@ -14,7 +13,6 @@ env:
   - _KERL_VSN=18.3
   - _KERL_VSN=17.5
   - _KERL_VSN=R16B03-1
-
 before_script: set -e
 after_script: set +e
 script:
@@ -38,3 +36,12 @@ script:
   fi
 - ./kerl delete installation $(./kerl path install_$_KERL_VSN)
 - ./kerl delete build "$_KERL_VSN"
+
+deploy:
+  - provider: pypi
+    user: kerl
+    password: your-secure-password
+    on:
+      tags: true
+    distributions: sdist bdist_wheel
+    skip_existing: true

--- a/README.md
+++ b/README.md
@@ -28,12 +28,23 @@ feel free to join and ask support or implementation questions any time. If
 no one is around, feel free to open an issue with your question or problem
 instead.
 
-Downloading
------------
+Installing
+----------
+
+### From brew
 
 If you are on MacOS, and using [homebrew](https://github.com/Homebrew/brew), you can install kerl, along with shell completion, by running:
 
     $ brew install kerl
+
+### From pypi
+
+You can choose to install `kerl` from [pypi](https://pypi.org), by using a python
+environment and by running:
+
+    $ pip install pykerl
+
+### From source
 
 Alternatively, you can download the script directly from github:
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,26 @@
+[metadata]
+name = pykerl
+description = Easy building and installing of Erlang/OTP instances.
+long_description = file: README.md
+long_description_content_type = text/markdown
+keywords = erlang, OTP, build, install
+license = GPL 3.0
+classifiers =
+    Framework :: Django
+    License :: OSI Approved :: GNU General Public License (GPL)
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.5
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+
+[options]
+zip_safe = False
+include_package_data = True
+scripts =
+  kerl
+
+setup_requires =
+  setuptools_scm
+
+[bdist_wheel]
+universal = 1

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,5 @@
+from setuptools import setup
+
+setup(
+    use_scm_version=True,
+)


### PR DESCRIPTION
Allow user to install kerl from [python pypi warehouse](https://pypi.org/).

These changes introduce a python packaging system for kerl.
They package kerl into a python package, deploy it to pypi and allow
users to install kerl from pypi by using:

pip install pykerl

The kerl project name is already in use on pypi so I decided to name
it pykerl.

The package version is based on the git tag version, so when you built a
a new version, the version retrieved correspond to your tags that
already existes.

The python package and deployed is built by using travis-ci. Everythings
is automatic, you just need to deploy a new git tag to your github repo
to deploy a new version on pypi.

By example if you create a tag `1.8.6` and after you push it on github
then a new package in version `1.8.6` will be available on pypi.

You don't need to bump the version manually for the python installer part.

/!\ 
**You need to create a pypi account first and to update the password section in the travis yaml file. Read  the following documentations for more informations:**
- https://docs.travis-ci.com/user/encryption-keys
- https://docs.travis-ci.com/user/deployment/pypi/

/!\