### PR TITLE
Catalina Fix

### DIFF
--- a/kerl
+++ b/kerl
@@ -742,6 +742,8 @@ _do_build() {
                     fi
                 fi
             fi
+
+
         ;;
         Linux)
             # we are going to check here to see if the Linux uses dpkg or rpms
@@ -765,9 +767,9 @@ _do_build() {
     cd "$ERL_TOP" || exit 1
     LOGFILE="$KERL_BUILD_DIR/$2/otp_build_$1.log"
 
-    if ! echo "$KERL_CONFIGURE_OPTIONS" | grep 'catalina' >/dev/null 2>&1; then
+    if [[ $KERL_SYSTEM == "Darwin" ]] && [[ $(uname -r) == "19"* ]]; then
         cd "$ERL_TOP"
-        
+            
         sed -i '.bak' ':t
             /case $host_os in/,/esac/ {    
                 /esac/!{         
@@ -779,14 +781,14 @@ _do_build() {
             /LDFLAGS="$LDFLAGS -Wl,-no_weak_imports"/c\
             case $host_os in \
             \ \darwin19*) \
-	        \ \AC_MSG_NOTICE([Turning off stack check on macOS 10.15 (Catalina)]) \
-	        \ \CFLAGS="-fno-stack-check $CFLAGS" \
-	        \ \;; \
+            \ \AC_MSG_NOTICE([Turning off stack check on macOS 10.15 (Catalina)]) \
+            \ \CFLAGS="-fno-stack-check $CFLAGS" \
+            \ \;; \
             \ \*) \
-	        \ \;; \
+            \ \;; \
             esac
             }
-            ' test_file
+            ' erts/configure.in
     fi
 
     # Set configuation flags given applications white/black lists

--- a/kerl
+++ b/kerl
@@ -599,8 +599,11 @@ maybe_patch() {
     release=$(get_otp_version "$2")
     case "$1" in
         Darwin)
+            # Catalina and clang require a "no-weaks-import" flag during build
+            if [[ $(uname -r) == "19"* ]]; then
+                apply_catalina_no_weak_imports_patch >>"$LOGFILE"
+            fi
             maybe_patch_darwin "$release"
-            maybe_patch_osx_catalina
             ;;
         SunOS)
             maybe_patch_sunos "$release"
@@ -656,30 +659,43 @@ maybe_patch_darwin() {
     fi
 }
 
-maybe_patch_osx_catalina() {
-    if [[ $(uname -r) == "19"* ]]; then
-    cd "$ERL_TOP"
-        
-    sed -i '.bak' ':t
-        /case $host_os in/,/esac/ {    
-            /esac/!{         
-                $!{          
-                    N;        
-                    bt
-                }               
-            }               
-        /LDFLAGS="$LDFLAGS -Wl,-no_weak_imports"/c\
-        case $host_os in \
-        \ \darwin19*) \
-        \ \AC_MSG_NOTICE([Turning off stack check on macOS 10.15 (Catalina)]) \
-        \ \CFLAGS="-fno-stack-check $CFLAGS" \
-        \ \;; \
-        \ \*) \
-        \ \;; \
-        esac
-        }
-        ' erts/configure.in
-    fi
+apply_catalina_no_weak_imports_patch() {
+    patch -p1 <<'_END_PATCH'
+diff --git a/erts/configure.in b/erts/configure.in
+index 3ba8216a19..d7cebc5ebc 100644
+--- a/erts/configure.in
++++ b/erts/configure.in
+@@ -926,20 +926,16 @@ dnl for now that is the way we do it.
+ USER_LD=$LD
+ USER_LDFLAGS="$LDFLAGS"
+ LD='$(CC)'
++
+ case $host_os in
+-     darwin*)
+-	saved_LDFLAGS="$LDFLAGS"
+-	LDFLAGS="$LDFLAGS -Wl,-no_weak_imports"
+-	AC_TRY_LINK([],[],
+-		[
+-			LD_MAY_BE_WEAK=no
+-		],
+-		[
+-			LD_MAY_BE_WEAK=yes
+-			LDFLAGS="$saved_LDFLAGS"
+-		]);;
+-    *)
+-	LD_MAY_BE_WEAK=no;;
++        darwin19*)
++	    # Disable stack checking to avoid crashing with a segment fault
++	    # in macOS Catalina.
++	    AC_MSG_NOTICE([Turning off stack check on macOS 10.15 (Catalina)])
++	    CFLAGS="-fno-stack-check $CFLAGS"
++	    ;;
++        *)
++	    ;;
+ esac
+ 
+ AC_SUBST(LD)
+_END_PATCH
 }
 
 maybe_patch_sunos() {

--- a/kerl
+++ b/kerl
@@ -768,29 +768,25 @@ _do_build() {
     if ! echo "$KERL_CONFIGURE_OPTIONS" | grep 'catalina' >/dev/null 2>&1; then
         cd "$ERL_TOP"
         
-        sed -i '.bak' '/banana/ a\
-            \
+        sed -i '.bak' ':t
+            /case $host_os in/,/esac/ {    
+                /esac/!{         
+                    $!{          
+                        N;        
+                        bt
+                    }               
+                }               
+            /LDFLAGS="$LDFLAGS -Wl,-no_weak_imports"/c\
             case $host_os in \
             \ \darwin19*) \
-	        AC_MSG_NOTICE([Turning off stack check on macOS 10.15 (Catalina)]) \
-	        CFLAGS="-fno-stack-check $CFLAGS" \
-	        ;; \
-            *) \
-	        ;; \
-            esac \
-            \
-            ' erts/configure.in
-        
-        sed ':t
-     /case $host_os in/,/esac/ {    
-        /esac/!{         
-           $!{          
-              N;        
-              bt
-           }            
-        }               
-        /LDFLAGS="$LDFLAGS -Wl,-no_weak_imports"/d;       
-     }' test_file
+	        \ \AC_MSG_NOTICE([Turning off stack check on macOS 10.15 (Catalina)]) \
+	        \ \CFLAGS="-fno-stack-check $CFLAGS" \
+	        \ \;; \
+            \ \*) \
+	        \ \;; \
+            esac
+            }
+            ' test_file
     fi
 
     # Set configuation flags given applications white/black lists

--- a/kerl
+++ b/kerl
@@ -600,7 +600,7 @@ maybe_patch() {
     case "$1" in
         Darwin)
             # Catalina and clang require a "no-weaks-import" flag during build
-            if [[ $(uname -r) == "19"* ]]; then
+            if [[ $(uname -r) == "19"* ]] && [[ "$release" -le 23 ]] && [[ $2 != "22.3.1" ]]; then
                 apply_catalina_no_weak_imports_patch >>"$LOGFILE"
             fi
             maybe_patch_darwin "$release"

--- a/kerl
+++ b/kerl
@@ -600,6 +600,7 @@ maybe_patch() {
     case "$1" in
         Darwin)
             maybe_patch_darwin "$release"
+            maybe_patch_osx_catalina
             ;;
         SunOS)
             maybe_patch_sunos "$release"
@@ -652,6 +653,32 @@ maybe_patch_darwin() {
         apply_r16_wx_ptr_patch >>"$LOGFILE"
     elif [ "$1" -ge 17 ] && [ "$1" -le 19 ]; then
         apply_wx_ptr_patch >>"$LOGFILE"
+    fi
+}
+
+maybe_patch_osx_catalina() {
+    if [[ $(uname -r) == "19"* ]]; then
+    cd "$ERL_TOP"
+        
+    sed -i '.bak' ':t
+        /case $host_os in/,/esac/ {    
+            /esac/!{         
+                $!{          
+                    N;        
+                    bt
+                }               
+            }               
+        /LDFLAGS="$LDFLAGS -Wl,-no_weak_imports"/c\
+        case $host_os in \
+        \ \darwin19*) \
+        \ \AC_MSG_NOTICE([Turning off stack check on macOS 10.15 (Catalina)]) \
+        \ \CFLAGS="-fno-stack-check $CFLAGS" \
+        \ \;; \
+        \ \*) \
+        \ \;; \
+        esac
+        }
+        ' erts/configure.in
     fi
 }
 
@@ -764,30 +791,6 @@ _do_build() {
     ERL_TOP="$KERL_BUILD_DIR/$2/otp_src_$1"
     cd "$ERL_TOP" || exit 1
     LOGFILE="$KERL_BUILD_DIR/$2/otp_build_$1.log"
-
-    if [[ $KERL_SYSTEM == "Darwin" ]] && [[ $(uname -r) == "19"* ]]; then
-        cd "$ERL_TOP"
-            
-        sed -i '.bak' ':t
-            /case $host_os in/,/esac/ {    
-                /esac/!{         
-                    $!{          
-                        N;        
-                        bt
-                    }               
-                }               
-            /LDFLAGS="$LDFLAGS -Wl,-no_weak_imports"/c\
-            case $host_os in \
-            \ \darwin19*) \
-            \ \AC_MSG_NOTICE([Turning off stack check on macOS 10.15 (Catalina)]) \
-            \ \CFLAGS="-fno-stack-check $CFLAGS" \
-            \ \;; \
-            \ \*) \
-            \ \;; \
-            esac
-            }
-            ' erts/configure.in
-    fi
 
     # Set configuation flags given applications white/black lists
     if [ -n "$KERL_CONFIGURE_APPLICATIONS" ]; then

--- a/kerl
+++ b/kerl
@@ -600,7 +600,7 @@ maybe_patch() {
     case "$1" in
         Darwin)
             # Catalina and clang require a "no-weaks-import" flag during build
-            if [[ $(uname -r) == "19"* ]] && [[ "$release" -le 23 ]] && [[ $2 != "22.3.1" ]]; then
+            if [[ $(uname -r) == "19"* ]] && [[ "$release" -lt 23 ]] && [[ $2 != "22.3.1" ]]; then
                 apply_catalina_no_weak_imports_patch >>"$LOGFILE"
             fi
             maybe_patch_darwin "$release"

--- a/kerl
+++ b/kerl
@@ -742,8 +742,6 @@ _do_build() {
                     fi
                 fi
             fi
-
-
         ;;
         Linux)
             # we are going to check here to see if the Linux uses dpkg or rpms
@@ -792,7 +790,6 @@ _do_build() {
     fi
 
     # Set configuation flags given applications white/black lists
-
     if [ -n "$KERL_CONFIGURE_APPLICATIONS" ]; then
         for app in $KERL_CONFIGURE_APPLICATIONS; do
             case "$KERL_CONFIGURE_OPTIONS" in

--- a/kerl
+++ b/kerl
@@ -765,7 +765,36 @@ _do_build() {
     cd "$ERL_TOP" || exit 1
     LOGFILE="$KERL_BUILD_DIR/$2/otp_build_$1.log"
 
+    if ! echo "$KERL_CONFIGURE_OPTIONS" | grep 'catalina' >/dev/null 2>&1; then
+        cd "$ERL_TOP"
+        
+        sed -i '.bak' '/banana/ a\
+            \
+            case $host_os in \
+            \ \darwin19*) \
+	        AC_MSG_NOTICE([Turning off stack check on macOS 10.15 (Catalina)]) \
+	        CFLAGS="-fno-stack-check $CFLAGS" \
+	        ;; \
+            *) \
+	        ;; \
+            esac \
+            \
+            ' erts/configure.in
+        
+        sed ':t
+     /case $host_os in/,/esac/ {    
+        /esac/!{         
+           $!{          
+              N;        
+              bt
+           }            
+        }               
+        /LDFLAGS="$LDFLAGS -Wl,-no_weak_imports"/d;       
+     }' test_file
+    fi
+
     # Set configuation flags given applications white/black lists
+
     if [ -n "$KERL_CONFIGURE_APPLICATIONS" ]; then
         for app in $KERL_CONFIGURE_APPLICATIONS; do
             case "$KERL_CONFIGURE_OPTIONS" in


### PR DESCRIPTION
This PR fallows users on OSX Catalina to correctly build OTP versions. According to https://github.com/kerl/kerl/issues/335#issuecomment-605487028 "21 and below was never was and will not be supported on Catalina 10.15.4, unfortunately."