### PR TITLE
Use POSIX -path flag instead of GNU -wholename flag for find.

### DIFF
--- a/kerl
+++ b/kerl
@@ -1162,7 +1162,7 @@ set -x _KERL_MANPATH_REMOVABLE "$absdir/lib/erlang/man" "$absdir/man"
 set -x MANPATH \$MANPATH "\$_KERL_MANPATH_REMOVABLE"
 set -x REBAR_PLT_DIR "$absdir"
 set -x _KERL_ACTIVE_DIR "$absdir"
-set -x _KERL_ERL_CALL_REMOVABLE (find "$absdir" -type d -wholename "*erl_interface*/bin")
+set -x _KERL_ERL_CALL_REMOVABLE (find "$absdir" -type d -path "*erl_interface*/bin")
 set -x PATH "\$_KERL_ERL_CALL_REMOVABLE" \$PATH
 
 if test -f "$KERL_CONFIG.fish"


### PR DESCRIPTION
Here is a minor patch to the activate script. The activate script was producing an error message on OpenBSD 6.6. The error was:

> find: -wholename: unknown option

`-path` is equivalent to `-wholename` according to the GNU doc here:

https://www.gnu.org/software/findutils/manual/html_mono/find.html#Full-Name-Patterns

Thanks,
Justin