### PR TITLE
Redownload github tarball if corrupted

### DIFF
--- a/kerl
+++ b/kerl
@@ -725,7 +725,7 @@ index 3ba8216a19..d7cebc5ebc 100644
 +        *)
 +	    ;;
  esac
- 
+
  AC_SUBST(LD)
 _END_PATCH
 }
@@ -1760,10 +1760,20 @@ download() {
 }
 
 github_download() {
+    tarball_file="$KERL_DOWNLOAD_DIR/$1"
+    tarball_url="$OTP_GITHUB_URL/archive/$1"
     # if the file doesn't exist or the file has no size
-    if [ ! -s "$KERL_DOWNLOAD_DIR/$1" ]; then
-        echo "Downloading $1 to $KERL_DOWNLOAD_DIR"
-        curl -f -L -o "$KERL_DOWNLOAD_DIR/$1" "$OTP_GITHUB_URL/archive/$1" || exit 1
+    if [ ! -s $tarball_file ]; then
+        echo "Downloading $1 to $KERL_DOWNLOAD_DIR..."
+        curl -f -L -o $tarball_file $tarball_url || exit 1
+    else
+        # If the downloaded tarball was corrupted due to interruption while
+        # downloading.
+        if ! gunzip -t $tarball_file 2>/dev/null; then
+            echo "$tarball_file corrupted and redownloading..."
+            rm -rf $tarball_file
+            curl -f -L -o $tarball_file $tarball_url || exit 1
+        fi
     fi
 }
 
@@ -1815,7 +1825,7 @@ apply_darwin_compiler_patch() {
 +++ erts/emulator/beam/beam_bp.c	2013-10-04 13:42:03.000000000 -0500
 @@ -496,7 +496,8 @@
  }
- 
+
  /* bp_hash */
 -ERTS_INLINE Uint bp_sched2ix() {
 +#ifndef ERTS_DO_INCL_GLB_INLINE_FUNC_DEF
@@ -1836,7 +1846,7 @@ apply_darwin_compiler_patch() {
 @@ -144,7 +144,19 @@
  #define ErtsSmpBPUnlock(BDC)
  #endif
- 
+
 -ERTS_INLINE Uint bp_sched2ix(void);
 +ERTS_GLB_INLINE Uint bp_sched2ix(void);
 +
@@ -1851,7 +1861,7 @@ apply_darwin_compiler_patch() {
 +#endif
 +}
 +#endif
- 
+
  #ifdef ERTS_SMP
  #define bp_sched2ix_proc(p) ((p)->scheduler_data->no - 1)
 _END_PATCH
@@ -1866,13 +1876,13 @@ apply_javadoc_linting_patch() {
 +++ lib/jinterface/doc/src/Makefile	2016-05-23 14:35:48.000000000 -0500
 @@ -142,7 +142,7 @@
  	rm -f errs core *~
- 
+
  jdoc:$(JAVA_SRC_FILES)
 -	(cd ../../java_src;$(JAVADOC) -sourcepath . -d $(JAVADOC_DEST) \
 +	(cd ../../java_src;$(JAVADOC) -Xdoclint:none -sourcepath . -d $(JAVADOC_DEST) \
  		-windowtitle $(JAVADOC_TITLE) $(JAVADOC_PKGS))
- 
- man: 
+
+ man:
 _END_PATCH
 }
 
@@ -1883,7 +1893,7 @@ apply_r14_beam_makeops_patch() {
 +++ erts/emulator/utils/beam_makeops	2016-05-23 21:41:08.000000000 -0500
 @@ -1576,7 +1576,7 @@
  	if $min_window{$key} > $min_window;
- 
+
      pop(@{$gen_transform{$key}})
 -	if defined @{$gen_transform{$key}}; # Fail
 +	if defined $gen_transform{$key}; # Fail
@@ -1903,7 +1913,7 @@ apply_r15_beam_makeops_patch() {
      $prev_last = pop(@{$gen_transform{$key}})
 -	if defined @{$gen_transform{$key}}; # Fail
 +	if defined $gen_transform{$key}; # Fail
- 
+
      if ($prev_last && !is_instr($prev_last, 'fail')) {
  	error("Line $line: A previous transformation shadows '$orig_transform'");
 _END_PATCH
@@ -1976,13 +1986,13 @@ index 656de7c49ad..4491d486837 100644
 @@ -1193,6 +1193,7 @@ typedef struct B2TContext_t {
      } u;
  } B2TContext;
- 
+
 +static B2TContext* b2t_export_context(Process*, B2TContext* src);
- 
+
  static uLongf binary2term_uncomp_size(byte* data, Sint size)
  {
 @@ -1225,7 +1226,7 @@ static uLongf binary2term_uncomp_size(byte* data, Sint size)
- 
+
  static ERTS_INLINE int
  binary2term_prepare(ErtsBinary2TermState *state, byte *data, Sint data_size,
 -		    B2TContext* ctx)
@@ -2022,7 +2032,7 @@ index 656de7c49ad..4491d486837 100644
 +
  	    if (erl_zlib_inflate_start(&ctx->u.uc.stream, bytes, size) != Z_OK)
  		return -1;
- 
+
  	    ctx->u.uc.dbytes = state->extp;
  	    ctx->u.uc.dleft = dest_len;
  	    ctx->state = B2TUncompressChunk;
@@ -2033,11 +2043,11 @@ index 656de7c49ad..4491d486837 100644
 @@ -1308,7 +1319,7 @@ erts_binary2term_prepare(ErtsBinary2TermState *state, byte *data, Sint data_size
  {
      Sint res;
- 
+
 -    if (binary2term_prepare(state, data, data_size, NULL) < 0 ||
 +    if (binary2term_prepare(state, data, data_size, NULL, NULL) < 0 ||
          (res=decoded_size(state->extp, state->extp + state->extsize, 0, NULL)) < 0) {
- 
+
          if (state->exttmp)
 @@ -1435,7 +1446,7 @@ static Eterm binary_to_term_int(Process* p, Uint32 flags, Eterm bin, Binary* con
              if (ctx->aligned_alloc) {


### PR DESCRIPTION
This PR updates the download part of the build command so that when a downloaded tarball was corrupted (due to interruption during downloading), the script will redownload the same tarball again.

To simulate an interrupted download.
```
$ ./kerl build 20.0 20.0
Downloading OTP-20.0.tar.gz to /home/foobar/.kerl/archives...
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   120  100   120    0     0    218      0 --:--:-- --:--:-- --:--:--   217
100 3720k    0 3720k    0     0  1555k      0 --:--:--  0:00:02 --:--:-- 4070k^C
```

Rebuiling the same release failed to due corrupted tarball.
```
$ ./kerl build 20.0 20.0
Extracting source code

gzip: stdin: unexpected end of file
tar: Unexpected EOF in archive
tar: Unexpected EOF in archive
tar: Error is not recoverable: exiting now
Building Erlang/OTP 20.0 (20.0), please wait...
./kerl: 840: cd: can't cd to /home/foobar/.kerl/builds/20.0/otp_src_20.0
```

Patch the script to redownload any corrupted tarball during build command if found.
```
$ ./kerl build 20.0 20.0
/home/foobar/.kerl/archives/OTP-20.0.tar.gz corrupted and redownloading...
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   120  100   120    0     0    191      0 --:--:-- --:--:-- --:--:--   191
100 50.3M    0 50.3M    0     0  4974k      0 --:--:--  0:00:10 --:--:-- 5647k
Extracting source code
Building Erlang/OTP 20.0 (20.0), please wait...
APPLICATIONS DISABLED (See: /home/foobar/.kerl/builds/20.0/otp_build_20.0.log)
 * odbc           : ODBC library - link check failed

Erlang/OTP 20.0 (20.0) has been successfully built
```

If the downloaded tarball is not corrupted, rebuilding the release.
```
$ sed -i '/^20.0/d' ~/.kerl/otp_builds
$ ./kerl build 20.0 20.0
Extracting source code
Building Erlang/OTP 20.0 (20.0), please wait...
APPLICATIONS DISABLED (See: /home/foobar/.kerl/builds/20.0/otp_build_20.0.log)
 * odbc           : ODBC library - link check failed

Erlang/OTP 20.0 (20.0) has been successfully built
```