### PR TITLE
Apply Erlang patch to build on OSX Big Sur

### DIFF
--- a/kerl
+++ b/kerl
@@ -602,6 +602,7 @@ maybe_patch() {
             maybe_patch_darwin "$release"
             # Catalina and clang require a "no-weaks-import" flag during build
             maybe_patch_catalina "$release" "$2"
+            maybe_patch_bigsur "$release"
             ;;
         SunOS)
             maybe_patch_sunos "$release"
@@ -728,6 +729,79 @@ index 3ba8216a19..d7cebc5ebc 100644
  esac
 
  AC_SUBST(LD)
+_END_PATCH
+}
+
+# https://github.com/erlang/otp/commit/f1044ef9e35da26f276b8127640e177d67aade6a.diff
+maybe_patch_bigsur() {
+    release="$1"
+    if is_osx_bigsur && \
+        [[ "$release" -lt 24 ]]; then
+        apply_bigsur_remove_version_check_patch >>"$LOGFILE"
+    fi
+}
+
+is_osx_bigsur() {
+    [[ $(uname -r) == "20"* ]]
+}
+
+apply_bigsur_remove_version_check_patch() {
+    patch -p1 <<'_END_PATCH'
+diff --git a/make/configure.in b/make/configure.in
+index 898aa40c4a0..ee2fa840cf8 100644
+--- a/make/configure.in
++++ b/make/configure.in
+@@ -387,50 +387,6 @@ if test X${enable_native_libs} = Xyes -a X${enable_hipe} != Xno; then
+ fi
+ AC_SUBST(NATIVE_LIBS_ENABLED)
+
+-if test $CROSS_COMPILING = no; then
+-   case $host_os in
+-   	darwin*)
+-	   macosx_version=`sw_vers -productVersion`
+-	   test $? -eq 0 || {
+-	   	AC_MSG_ERROR([Failed to execute 'sw_vers'; please provide it in PATH])
+-	   }
+-	   [case "$macosx_version" in
+-	       [1-9][0-9].[0-9])
+-	          int_macosx_version=`echo $macosx_version | sed 's|\([^\.]*\)\.\([^\.]*\)|\10\200|'`;;
+-	       [1-9][0-9].[0-9].[0-9])
+-	          int_macosx_version=`echo $macosx_version | sed 's|\([^\.]*\)\.\([^\.]*\)\.\([^\.]*\)|\1\2\3|'`;;
+-	       [1-9][0-9].[1-9][0-9])
+-	          int_macosx_version=`echo $macosx_version | sed 's|\([^\.]*\)\.\([^\.]*\)|\1\200|'`;;
+-	       [1-9][0-9].[1-9][0-9].[0-9])
+-	          int_macosx_version=`echo $macosx_version | sed 's|\([^\.]*\)\.\([^\.]*\)\.\([^\.]*\)|\1\20\3|'`;;
+-	       [1-9][0-9].[1-9][0-9].[1-9][0-9])
+-	          int_macosx_version=`echo $macosx_version | sed 's|\([^\.]*\)\.\([^\.]*\)\.\([^\.]*\)|\1\2\3|'`;;
+-	       *)
+-		  int_macosx_version=unexpected;;
+-	   esac]
+-	   test $int_macosx_version != unexpected || {
+-	   	AC_MSG_ERROR([Unexpected MacOSX version ($macosx_version) returned by 'sw_vers -productVersion'; this configure script probably needs to be updated])
+-	   }
+-	   AC_TRY_COMPILE([
+-#if __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ > $int_macosx_version
+-#error Compiling for a newer MacOSX version...
+-#endif
+-		], [;],
+-		[],
+-		[AC_MSG_ERROR([
+-
+-  You are natively building Erlang/OTP for a later version of MacOSX
+-  than current version ($macosx_version). You either need to
+-  cross-build Erlang/OTP, or set the environment variable
+-  MACOSX_DEPLOYMENT_TARGET to $macosx_version (or a lower version).
+-
+-])])
+-	   ;;
+-	*)
+-	   ;;
+-   esac
+-fi
+-
+ ERL_DED
+
+ AC_CONFIG_FILES([../Makefile output.mk ../make/$host/otp_ded.mk:../make/otp_ded.mk.in])
 _END_PATCH
 }
 


### PR DESCRIPTION
This applies https://github.com/erlang/otp/commit/f1044ef9e35da26f276b8127640e177d67aade6a which currently exists in `master` to fix an error when configuring the build on OSX Big Sur.

See https://github.com/erlang/otp/pull/2871 for details.

Fixes https://github.com/kerl/kerl/issues/346.

Tested with this configuration.

  - OSX 11.0.1
  - OTP 23.1.4 and 23.1.5