### PR TITLE
Replace Big Sur patch with sed-based bypass for installing OTP 21, 22, and 23

### DIFF
--- a/kerl
+++ b/kerl
@@ -737,7 +737,7 @@ maybe_patch_bigsur() {
     release="$1"
     if is_osx_bigsur && \
         [[ "$release" -lt 24 ]]; then
-        apply_bigsur_remove_version_check_patch >>"$LOGFILE"
+        apply_bigsur_bypass_version_check >>"$LOGFILE"
     fi
 }
 
@@ -745,64 +745,16 @@ is_osx_bigsur() {
     [[ $(uname -r) == "20"* ]]
 }
 
-apply_bigsur_remove_version_check_patch() {
-    patch -p1 <<'_END_PATCH'
-diff --git a/make/configure.in b/make/configure.in
-index 898aa40c4a0..ee2fa840cf8 100644
---- a/make/configure.in
-+++ b/make/configure.in
-@@ -387,50 +387,6 @@ if test X${enable_native_libs} = Xyes -a X${enable_hipe} != Xno; then
- fi
- AC_SUBST(NATIVE_LIBS_ENABLED)
-
--if test $CROSS_COMPILING = no; then
--   case $host_os in
--   	darwin*)
--	   macosx_version=`sw_vers -productVersion`
--	   test $? -eq 0 || {
--	   	AC_MSG_ERROR([Failed to execute 'sw_vers'; please provide it in PATH])
--	   }
--	   [case "$macosx_version" in
--	       [1-9][0-9].[0-9])
--	          int_macosx_version=`echo $macosx_version | sed 's|\([^\.]*\)\.\([^\.]*\)|\10\200|'`;;
--	       [1-9][0-9].[0-9].[0-9])
--	          int_macosx_version=`echo $macosx_version | sed 's|\([^\.]*\)\.\([^\.]*\)\.\([^\.]*\)|\1\2\3|'`;;
--	       [1-9][0-9].[1-9][0-9])
--	          int_macosx_version=`echo $macosx_version | sed 's|\([^\.]*\)\.\([^\.]*\)|\1\200|'`;;
--	       [1-9][0-9].[1-9][0-9].[0-9])
--	          int_macosx_version=`echo $macosx_version | sed 's|\([^\.]*\)\.\([^\.]*\)\.\([^\.]*\)|\1\20\3|'`;;
--	       [1-9][0-9].[1-9][0-9].[1-9][0-9])
--	          int_macosx_version=`echo $macosx_version | sed 's|\([^\.]*\)\.\([^\.]*\)\.\([^\.]*\)|\1\2\3|'`;;
--	       *)
--		  int_macosx_version=unexpected;;
--	   esac]
--	   test $int_macosx_version != unexpected || {
--	   	AC_MSG_ERROR([Unexpected MacOSX version ($macosx_version) returned by 'sw_vers -productVersion'; this configure script probably needs to be updated])
--	   }
--	   AC_TRY_COMPILE([
--#if __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ > $int_macosx_version
--#error Compiling for a newer MacOSX version...
--#endif
--		], [;],
--		[],
--		[AC_MSG_ERROR([
--
--  You are natively building Erlang/OTP for a later version of MacOSX
--  than current version ($macosx_version). You either need to
--  cross-build Erlang/OTP, or set the environment variable
--  MACOSX_DEPLOYMENT_TARGET to $macosx_version (or a lower version).
--
--])])
--	   ;;
--	*)
--	   ;;
--   esac
--fi
--
- ERL_DED
-
- AC_CONFIG_FILES([../Makefile output.mk ../make/$host/otp_ded.mk:../make/otp_ded.mk.in])
-_END_PATCH
+apply_bigsur_bypass_version_check() {
+    if [ -f make/configure.in ]; then
+        echo "Bypassing version check in make/configure.in for Big Sur"
+        sed -i '' 's/\(#if __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ > $int_macosx_version\)/\1 \&\& false/' make/configure.in
+    elif [ -f configure.in ]; then
+        echo "Bypassing version check in configure.in for Big Sur"
+        sed -i '' 's/\(#if __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ > $int_macosx_version\)/\1 \&\& false/' configure.in
+        echo "Removng no_weak_imports from LDFLAGS in erts/configure.in for Big Sur"
+        sed -i '' 's/LDFLAGS="$LDFLAGS -Wl,-no_weak_imports"//' erts/configure.in
+    fi
 }
 
 maybe_patch_sunos() {


### PR DESCRIPTION
The patch added in #356 (to release 2.0.2) only applies to OTP 23, and doesn't work with earlier OTP versions. This PR provides an alternative approach.

This version has been tested with the latest versions of OTP 23, 22, and 21. I've also tested with OTP 20, but the build fails at a later point for (from what I can see) unrelated reasons.