### PR TITLE
Automate building a "debug" Erlang instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,12 @@ Default: `${KERL_BASE_DIR}/archives`
 Directory in which to place downloaded artefacts
 
 
+### KERL_BUILD_DEBUG_VM
+
+Allows building, alongside the regular VM, a debug VM (available via `cerl -debug`).
+NB: Enable this build using `KERL_BUILD_DEBUG_VM=true`
+
+
 ### KERL_BUILD_DIR
 
 Default: `${KERL_BASE_DIR}/builds

--- a/kerl
+++ b/kerl
@@ -1037,6 +1037,11 @@ _do_build() {
     ERL_TOP="$ERL_TOP" ./otp_build release -a "$KERL_BUILD_DIR/$2/release_$1" >/dev/null 2>&1
     cd "$KERL_BUILD_DIR/$2/release_$1" || exit 1
     ./Install $INSTALL_OPT "$KERL_BUILD_DIR/$2/release_$1" >/dev/null 2>&1
+    if [ -n "$KERL_BUILD_DEBUG_VM" ]; then
+        echo 'Building debug VM...'
+        cd $ERL_TOP/erts/emulator || exit 1
+        make debug ERL_TOP=$ERL_TOP >>"$LOGFILE" 2>&1
+    fi
 }
 
 do_install() {
@@ -1056,6 +1061,14 @@ do_install() {
               cd "$absdir" && ./Install $INSTALL_OPT "$absdir" >/dev/null 2>&1); then
         echo "Couldn't install Erlang/OTP $rel ($1) in $absdir"
         exit 1
+    fi
+    BEAM_DEBUG_SMP=$(find . -name beam.debug.smp)
+    if [ "$BEAM_DEBUG_SMP" != "" ]; then
+        ERL_CHILD_SETUP_DEBUG=$(find . -name erl_child_setup.debug)
+        echo "Also installing Erlang/OTP $rel ($1) debug VM in $absdir..."
+        cp $BEAM_DEBUG_SMP $absdir/erts-*/bin/
+        cp $ERL_CHILD_SETUP_DEBUG $absdir/erts-*/bin/
+        cp bin/cerl $absdir/bin
     fi
     list_add installations "$1 $absdir";
     cat <<ACTIVATE >"$absdir"/activate

--- a/kerl
+++ b/kerl
@@ -1038,7 +1038,7 @@ _do_build() {
     cd "$KERL_BUILD_DIR/$2/release_$1" || exit 1
     ./Install $INSTALL_OPT "$KERL_BUILD_DIR/$2/release_$1" >/dev/null 2>&1
     if [ -n "$KERL_BUILD_DEBUG_VM" ]; then
-        echo 'Building debug VM...'
+        echo "Also building Erlang/OTP $1 ($2) debug VM, please wait..."
         cd $ERL_TOP/erts/emulator || exit 1
         make debug ERL_TOP=$ERL_TOP >>"$LOGFILE" 2>&1
     fi


### PR DESCRIPTION
Hopefully closes #321.

I'm opening this as a draft since it's surely not up to `kerl` requirements, yet. At the same time, though, I'd like some guidance on how to move this forward.

What I think is missing:

- [x] ~release name (should it be something like 19.3-debug?, where `debug` would be added by this new feature)~
- [x] making this optional, since I don't think we will build a debug VM with the previous build, all the time (I'd like guidance on the option name, or even if we should consider and ENV var, e.g. `KERL_BUILD_DEBUG_VM=true`, as is proposed at the moment)
- [x] ~a proper way to "activate" this build (if the name is, in fact, `...-debug` this should be a no-brainer (?)).~