### PR TITLE
Pin Homebrew OpenSSL version to @1.1

### DIFF
--- a/kerl
+++ b/kerl
@@ -827,7 +827,7 @@ _do_build() {
             if ! echo "$KERL_CONFIGURE_OPTIONS" | \grep 'with-ssl' >/dev/null 2>&1; then
                 whichbrew=$(command -v brew)
                 if [ -n "$whichbrew" ] && [ -x "$whichbrew" ]; then
-                    brew_prefix=$(brew --prefix openssl)
+                    brew_prefix=$(brew --prefix openssl@1.1)
                     if [ -n "$brew_prefix" ] && [ -d "$brew_prefix" ]; then
                         KERL_CONFIGURE_OPTIONS="$KERL_CONFIGURE_OPTIONS "--with-ssl=$brew_prefix
                     fi


### PR DESCRIPTION
Since the release of OpenSSL 3.0 Homebrew defaults to that version, but Erlang/OTP currenly doesn't support OpenSSL 3.0.

This either results in a build failure (when `@3` is installed) or in Erlang/OTP to be build without ssl/crypto support (when `@3` is not installed). 

Pinning the version to `@1.1` fixes the problem, until Erlang/OTP support OpenSSL 3.0