### PR TITLE
Bypass version check when building on MacOS Monterey

### DIFF
--- a/kerl
+++ b/kerl
@@ -752,12 +752,12 @@ is_osx_monterey() {
 
 apply_bypass_version_check() {
     if [ -f make/configure.in ]; then
-        echo "Bypassing version check in make/configure.in for Big Sur"
+        echo "Bypassing version check in make/configure.in"
         sed -i '' 's/\(#if __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ > $int_macosx_version\)/\1 \&\& false/' make/configure.in
     elif [ -f configure.in ]; then
-        echo "Bypassing version check in configure.in for Big Sur"
+        echo "Bypassing version check in configure.in"
         sed -i '' 's/\(#if __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ > $int_macosx_version\)/\1 \&\& false/' configure.in
-        echo "Removng no_weak_imports from LDFLAGS in erts/configure.in for Big Sur"
+        echo "Removing no_weak_imports from LDFLAGS in erts/configure.in"
         sed -i '' 's/LDFLAGS="$LDFLAGS -Wl,-no_weak_imports"//' erts/configure.in
     fi
 }

--- a/kerl
+++ b/kerl
@@ -600,7 +600,7 @@ maybe_patch() {
             maybe_patch_darwin "$release"
             # Catalina and clang require a "no-weaks-import" flag during build
             maybe_patch_catalina "$release" "$2"
-            maybe_patch_bigsur "$release"
+            maybe_patch_macos_version_check "$release"
             ;;
         SunOS)
             maybe_patch_sunos "$release"
@@ -733,11 +733,11 @@ _END_PATCH
 }
 
 # https://github.com/erlang/otp/commit/f1044ef9e35da26f276b8127640e177d67aade6a.diff
-maybe_patch_bigsur() {
+maybe_patch_macos_version_check() {
     release="$1"
-    if is_osx_bigsur && \
+    if is_osx_bigsur || is_osx_monterey && \
         [[ "$release" -lt 24 ]]; then
-        apply_bigsur_bypass_version_check >>"$LOGFILE"
+        apply_bypass_version_check >>"$LOGFILE"
         KERL_USE_AUTOCONF=1
     fi
 }
@@ -746,7 +746,11 @@ is_osx_bigsur() {
     [[ $(uname -r) == "20"* ]]
 }
 
-apply_bigsur_bypass_version_check() {
+is_osx_monterey() {
+    [[ $(uname -r) == "21"* ]]
+}
+
+apply_bypass_version_check() {
     if [ -f make/configure.in ]; then
         echo "Bypassing version check in make/configure.in for Big Sur"
         sed -i '' 's/\(#if __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ > $int_macosx_version\)/\1 \&\& false/' make/configure.in


### PR DESCRIPTION
Fixes: #394

Build of some older version of Erlang fails on MacOS Montery (12)

A similar issue was affecting MacOS Big Sur 
I've changed the kerl script to apply the same solution currently implemented for Big Sur


I've tested the solution as follow:

```
➜  kerl git:(master) ./kerl build 22.3
Downloading 22.3 to /Users/flavio/.kerl/archives...
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   652  100   652    0     0   4571      0 --:--:-- --:--:-- --:--:--  4759
100 83.8M  100 83.8M    0     0  18.6M      0  0:00:04  0:00:04 --:--:-- 20.4M
Extracting source code
Building Erlang/OTP 22.3 (22.3), please wait...
Build failed.

  You are natively building Erlang/OTP for a later version of MacOSX
  than current version (12.1). You either need to
  cross-build Erlang/OTP, or set the environment variable
  MACOSX_DEPLOYMENT_TARGET to 12.1 (or a lower version).


ERROR: /Users/flavio/.kerl/builds/22.3/otp_src_22.3/make/configure failed!
make: *** No rule to make target `is_cross_configured'.  Stop.
make: *** No rule to make target `all'.  Stop.

Please see /Users/flavio/.kerl/builds/22.3/otp_build_22.3.log for full details.
➜  kerl git:(master) git checkout patch-macos-monterey
Switched to branch 'patch-macos-monterey'
➜  kerl git:(patch-macos-monterey) ./kerl build 22.3
Extracting source code
Building Erlang/OTP 22.3 (22.3), please wait...
APPLICATIONS DISABLED (See: /Users/flavio/.kerl/builds/22.3/otp_build_22.3.log)
 * jinterface     : Java compiler disabled by user

APPLICATIONS INFORMATION (See: /Users/flavio/.kerl/builds/22.3/otp_build_22.3.log)
 * wx             : wxWidgets not found, wx will NOT be usable

DOCUMENTATION INFORMATION (See: /Users/flavio/.kerl/builds/22.3/otp_build_22.3.log)
 * documentation  :
 *                  fop is missing.
 *                  Using fakefop to generate placeholder PDF files.

Erlang/OTP 22.3 (22.3) has been successfully built
```