### PR TITLE
Add autoclean on build failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,11 @@ Directory in which kerl will clone git repositories for building.
 
 ## Build configuration
 
+### KERL_AUTOCLEAN
+
+Default: 1 (Enabled)
+Clean all build artefacts but logfile on failure. This allow safe build retries after failure while still keeping logfile with all attempts logs, until success. Set to 0 to keep build artefacts on failure.
+
 ### KERL_CONFIGURE_OPTIONS
 
 Space-separated options to pass to `configure` when building OTP.

--- a/kerl
+++ b/kerl
@@ -644,10 +644,10 @@ show_configuration_warnings() {
 }
 
 show_logfile() {
-    echo "$1"
-    tail "$2"
-    echo
-    echo "Please see $2 for full details."
+    l=e stderr "$1"
+    tail "$2" 1>&2
+    stderr ""
+    l=t stderr "Please see $2 for full details."
 }
 
 maybe_patch() {

--- a/kerl
+++ b/kerl
@@ -82,6 +82,26 @@ colorize()
     echo -n "$ret"
 }
 
+autoclean()
+{
+    if [ ${KERL_AUTOCLEAN:=1} -eq 1 ]; then
+        l=n stderr "Cleaning all artefacts but logfile"
+        l=t stderr "Consider use of KERL_AUTOCLEAN=0 to keep build artefacts on failure if necessary"
+        # Save LOGFILE
+        tmplf="$(mktemp "$TMP_DIR"/kerl.XXXXXX)"
+        test -f "$LOGFILE" && cp -f "$LOGFILE" "$tmplf"
+        # Cleaning current build
+        cd - 1>/dev/null 2>&1
+        test -n "$1" && $0 cleanup "$1"
+        # Copy LOGFILE back to keep track of all attempts until success
+        mkdir -p "$(dirname "$LOGFILE")"
+        mv -f "$tmplf" "$LOGFILE"
+        unset tmplf
+    else
+        l=w stderr "Autoclean on failure disabled"
+    fi
+}
+
 TMP_DIR=${TMP_DIR:-'/tmp'}
 if [ -z "$HOME" ]; then
     # shellcheck disable=SC2016
@@ -920,6 +940,9 @@ _do_build() {
     ERL_TOP="$KERL_BUILD_DIR/$2/otp_src_$1"
     cd "$ERL_TOP" || exit 1
     LOGFILE="$KERL_BUILD_DIR/$2/otp_build_$1.log"
+    # Add a build date and env in logfile
+    echo "*** $(date) - kerl build $1 ***" >> "$LOGFILE"
+    env | grep KERL_BUILD_ | xargs -n1 echo "*" >> "$LOGFILE"
 
     # Set configuation flags given applications white/black lists
     if [ -n "$KERL_CONFIGURE_APPLICATIONS" ]; then
@@ -986,6 +1009,7 @@ _do_build() {
         # shellcheck disable=SC2086
         if ! _flags ./otp_build configure $KERL_CONFIGURE_OPTIONS >>"$LOGFILE" 2>&1; then
             show_logfile 'Configure failed.' "$LOGFILE"
+            autoclean "$2"
             list_remove builds "$1 $2"
             exit 1
         fi
@@ -1003,6 +1027,7 @@ _do_build() {
             if ! rm ./lib/"$app"/SKIP; then
                 l=e stderr "Couldn't prepare '$app' application for building"
                 list_remove builds "$1 $2"
+                autoclean "$2"
                 exit 1
             fi
         done
@@ -1019,6 +1044,7 @@ _do_build() {
     # shellcheck disable=SC2086
     if ! _flags ./otp_build boot -a $KERL_CONFIGURE_OPTIONS >>"$LOGFILE" 2>&1; then
         show_logfile 'Build failed.' "$LOGFILE"
+        autoclean "$2"
         list_remove builds "$1 $2"
         exit 1
     fi
@@ -1027,11 +1053,13 @@ _do_build() {
         release=$(get_otp_version "$2")
         if ! make docs "DOC_TARGETS=$KERL_DOC_TARGETS" >>"$LOGFILE" 2>&1; then
             show_logfile 'Building docs failed.' "$LOGFILE"
+            autoclean "$2"
             list_remove builds "$1 $2"
             exit 1
         fi
         if ! make release_docs "DOC_TARGETS=$KERL_DOC_TARGETS" "RELEASE_ROOT=$KERL_BUILD_DIR/$2/release_$1" >>"$LOGFILE" 2>&1; then
             show_logfile 'Release of docs failed.' "$LOGFILE"
+            autoclean "$2"
             list_remove builds "$1 $2"
             exit 1
         fi

--- a/kerl
+++ b/kerl
@@ -2481,9 +2481,9 @@ case "$1" in
                 l=n stderr "Cleaned up all compilation products under $KERL_BUILD_DIR"
                 ;;
             *)
-                l=n stderr "Cleaning up compilation products for $3"
-                rm -rf "${KERL_BUILD_DIR:?}/$3"
-                l=n stderr "Cleaned up compilation products for $3 under $KERL_BUILD_DIR"
+                l=n stderr "Cleaning up compilation products for $2"
+                rm -rf "${KERL_BUILD_DIR:?}/$2"
+                l=n stderr "Cleaned up compilation products for $2 under $KERL_BUILD_DIR"
                 ;;
         esac
         ;;


### PR DESCRIPTION
Configured by KERL_AUTOCLEAN variable (enabled by default).
Remove all build artefacts but logfile on failure if enabled.
This allow safe several attempts to build a release.

Logfile receive a banner for all build attempt with build variable at this time.

Fix #262