### PR TITLE
Test on Ubuntu 22.04 (while dropping 20.04)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         otp_vsn: [23, 24, 25, master, latest]
-        os: [ubuntu-18.04, ubuntu-20.04, macos-11, macos-12]
+        os: [ubuntu-20.04, ubuntu-22.04, macos-11, macos-12]
     steps:
       - name: Update env.
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        otp_vsn: [23, 24, 25, master, latest]
+        otp_vsn: [23, 24, 25, latest]
         os: [ubuntu-20.04, ubuntu-22.04, macos-11, macos-12]
     steps:
       - name: Update env.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         otp_vsn: [23, 24, 25, master]
-        os: [ubuntu-20.04, ubuntu-22.04, macos-11, macos-12]
+        os: [ubuntu-22.04, macos-12]
     steps:
       - name: Update env.
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
           echo "_KERL_VSN=${_VERSION}" >> $GITHUB_ENV
       - name: Build chosen version
         run: |
-          export MAKEFLAGS="-j$(getconf _NPROCESSORS_ONLN)"
+          export MAKEFLAGS=-j$(($(nproc) + 2))
           if ! KERL_DEBUG=true ./kerl build ${_KERL_PREFIX_GIT} ${_KERL_PREFIX_GIT_TARGET} \
                                             "${_KERL_VSN}" "${_KERL_VSN}"; then
             ## Print build log if it fails

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,11 +36,7 @@ jobs:
               lksctp-tools build-essential gcc-9 m4 fop xsltproc \
               default-jdk libxml2-utils procps valgrind binutils
           fi
-          if [[ ${{matrix.os}} == macos* ]]; then
-            echo 'KERL_RELEASE_TARGET=debug opt' >> $GITHUB_ENV
-          else
-            echo 'KERL_RELEASE_TARGET=debug opt gcov gprof valgrind lcnt' >> $GITHUB_ENV
-          fi
+          echo 'KERL_RELEASE_TARGET=debug opt' >> $GITHUB_ENV
       - name: Git checkout
         uses: actions/checkout@v3
       - name: Update OTP releases

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        otp_vsn: [23, 24, 25, latest]
+        otp_vsn: [23, 24, 25, master]
         os: [ubuntu-20.04, ubuntu-22.04, macos-11, macos-12]
     steps:
       - name: Update env.
@@ -49,10 +49,6 @@ jobs:
               echo '_KERL_PREFIX_GIT=git' >> $GITHUB_ENV
               echo '_KERL_PREFIX_GIT_TARGET=https://github.com/erlang/otp.git' >> $GITHUB_ENV
               echo 'KERL_BUILD_DOCS=true' >> $GITHUB_ENV
-              ;;
-            latest)
-              _VERSION=$(./kerl list releases | grep '^[0-9]' | tail -1)
-              echo "KERL_BUILD_DOCS=true" >> $GITHUB_ENV
               ;;
             *)
               _VERSION=$(./kerl list releases | grep "^${_VERSION}" | tail -1)


### PR DESCRIPTION
This PR introduces Ubuntu 22.04 and drops (deprecated Ubuntu 18.04), while also addressing some previous comments by @garazdawi, namely:

- dropping `latest` (in favor of `25` - already present in the CI matrix)
- decreasing the number of release targets (for faster CI) - if I got @garazdawi's comment right 😓 (**edit**: it seems to shave off at least around 20 min., from a previous 60+ min.)
- moving `$(getconf _NPROCESSORS_ONLN)` to `$(nproc)`, for readability