### PR TITLE
Fix shellcheck warning for unreachable code

### DIFF
--- a/kerl
+++ b/kerl
@@ -2600,6 +2600,6 @@ case "$1" in
         esac
         ;;
     *)
-        l=e stderr "unknown command: $1"; usage; exit 1
+        l=e stderr "unknown command: $1"; usage
         ;;
 esac


### PR DESCRIPTION
`usage` already performs `exit`, so the (now removed) `exit` is deemed unreachable.