### PR TITLE
Add handling of REBAR_CACHE_DIR env variable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,8 @@ jobs:
           diff activate-csh-new $(./kerl path install_"$_KERL_VSN")/activate.csh
           rm -f activate-csh-new
         # yamllint enable rule:line-length
+      - name: Test activate/cleanup
+        run: tests/activate_test.sh $_KERL_VSN
       - name: Delete installation
         run: ./kerl delete installation $(./kerl path install_"$_KERL_VSN")
       - name: Delete build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,8 +100,8 @@ jobs:
           diff activate-csh-new $(./kerl path install_"$_KERL_VSN")/activate.csh
           rm -f activate-csh-new
         # yamllint enable rule:line-length
-      - name: Test activate/cleanup
-        run: tests/activate_test.sh install_"$_KERL_VSN"
+      - name: Test activate/cleanup (sh/bash)
+        run: tests/activate_test.sh $_KERL_REL $_KERL_VSN $(./kerl path install_"$_KERL_VSN")
       - name: Delete installation
         run: ./kerl delete installation $(./kerl path install_"$_KERL_VSN")
       - name: Delete build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
           rm -f activate-csh-new
         # yamllint enable rule:line-length
       - name: Test activate/cleanup
-        run: tests/activate_test.sh $_KERL_VSN
+        run: tests/activate_test.sh install_"$_KERL_VSN"
       - name: Delete installation
         run: ./kerl delete installation $(./kerl path install_"$_KERL_VSN")
       - name: Delete build

--- a/kerl
+++ b/kerl
@@ -1213,9 +1213,14 @@ emit_activate() {
 # credits to virtualenv
 kerl_deactivate() {
     set -o allexport
-    if [ -n "\$_KERL_SAVED_ERL_AFLAGS" ]; then
-        ERL_AFLAGS="\$_KERL_SAVED_ERL_AFLAGS"
+    if [ -n "\${_KERL_ERL_AFLAGS_SET+x}" ]; then
+        if [ -n "\$_KERL_ERL_AFLAGS_SET" ]; then
+            ERL_AFLAGS="\$_KERL_SAVED_ERL_AFLAGS"
+        else
+            unset ERL_AFLAGS
+        fi
         unset _KERL_SAVED_ERL_AFLAGS
+        unset _KERL_ERL_AFLAGS_SET
     fi
     if [ -n "\$_KERL_PATH_REMOVABLE" ]; then
         # shellcheck disable=SC2001
@@ -1255,8 +1260,8 @@ kerl_deactivate() {
     if [ -n "\$_KERL_ERL_CALL_REMOVABLE" ]; then
         # shellcheck disable=SC2001
         PATH="\$(echo "\$PATH" | sed -e "s#\$_KERL_ERL_CALL_REMOVABLE:##")"
-        unset _KERL_ERL_CALL_REMOVABLE
     fi
+    unset _KERL_ERL_CALL_REMOVABLE
     if [ -n "\$BASH" ] || [ -n "\$ZSH_VERSION" ]; then
         hash -r
     fi
@@ -1295,14 +1300,22 @@ MANPATH="\${_KERL_MANPATH_REMOVABLE}:\$MANPATH"
 REBAR_CACHE_DIR="$directory/.cache/rebar3"
 REBAR_PLT_DIR="$directory"
 _KERL_ACTIVE_DIR="$directory"
-_KERL_ERL_CALL_REMOVABLE=\$(\\find $directory -type d -path "*erl_interface*/bin")
-PATH="\${_KERL_ERL_CALL_REMOVABLE}:\$PATH"
+_KERL_ERL_CALL_REMOVABLE=\$(\\find $directory -type d -path "*erl_interface*/bin" 2>/dev/null)
+if [ -n "\$_KERL_ERL_CALL_REMOVABLE" ]; then
+    PATH="\${_KERL_ERL_CALL_REMOVABLE}:\$PATH"
+fi
 # https://twitter.com/mononcqc/status/877544929496629248
-_KERL_SAVED_ERL_AFLAGS=" \$ERL_AFLAGS"
+_KERL_ERL_AFLAGS_SET="\${ERL_AFLAGS+x}"
 kernel_history=\$(echo "\$ERL_AFLAGS" | \\grep 'kernel shell_history' || true)
 if [ -z "\$kernel_history" ]; then
-    ERL_AFLAGS="-kernel shell_history enabled \$ERL_AFLAGS"
+    if [ -n "\$ERL_AFLAGS" ]; then
+        _KERL_SAVED_ERL_AFLAGS="\$ERL_AFLAGS"
+        ERL_AFLAGS="-kernel shell_history enabled \$ERL_AFLAGS"
+    else
+        ERL_AFLAGS="-kernel shell_history enabled"
+    fi
 fi
+unset kernel_history
 # shellcheck source=/dev/null
 if [ -f "$KERL_CONFIG" ]; then . "$KERL_CONFIG"; fi
 if [ -n "\$KERL_ENABLE_PROMPT" ]; then

--- a/kerl
+++ b/kerl
@@ -1227,13 +1227,23 @@ kerl_deactivate() {
         MANPATH="\$(echo "\$MANPATH" | sed -e "s#\$_KERL_MANPATH_REMOVABLE:##")"
         unset _KERL_MANPATH_REMOVABLE
     fi
-    if [ -n "\$_KERL_SAVED_REBAR_PLT_DIR" ]; then
-        REBAR_PLT_DIR="\$_KERL_SAVED_REBAR_PLT_DIR"
+    if [ -n "\${_KERL_REBAR_PLT_DIR_SET+x}" ]; then
+        if [ -n "\$_KERL_REBAR_PLT_DIR_SET" ]; then
+            REBAR_PLT_DIR="\$_KERL_SAVED_REBAR_PLT_DIR"
+        else
+            unset REBAR_PLT_DIR
+        fi
         unset _KERL_SAVED_REBAR_PLT_DIR
+        unset _KERL_REBAR_PLT_DIR_SET
     fi
-    if [ -n "\$_KERL_SAVED_REBAR_CACHE_DIR" ]; then
-        REBAR_CACHE_DIR="\$_KERL_SAVED_REBAR_CACHE_DIR"
+    if [ -n "\${_KERL_REBAR_CACHE_DIR_SET+x}" ]; then
+        if [ -n "\$_KERL_REBAR_CACHE_DIR_SET" ]; then
+            REBAR_CACHE_DIR="\$_KERL_SAVED_REBAR_CACHE_DIR"
+        else
+            unset REBAR_CACHE_DIR
+        fi
         unset _KERL_SAVED_REBAR_CACHE_DIR
+        unset _KERL_REBAR_CACHE_DIR_SET
     fi
     if [ -n "\$_KERL_ACTIVE_DIR" ]; then
         unset _KERL_ACTIVE_DIR
@@ -1272,6 +1282,9 @@ fi
 
 set -o allexport
 _KERL_SAVED_REBAR_CACHE_DIR="\$REBAR_CACHE_DIR"
+_KERL_REBAR_CACHE_DIR_SET="\${REBAR_CACHE_DIR+x}"
+_KERL_SAVED_REBAR_CACHE_DIR="\$REBAR_CACHE_DIR"
+_KERL_REBAR_PLT_DIR_SET="\${REBAR_PLT_DIR+x}"
 _KERL_SAVED_REBAR_PLT_DIR="\$REBAR_PLT_DIR"
 _KERL_PATH_REMOVABLE="$directory/bin"
 PATH="\${_KERL_PATH_REMOVABLE}:\$PATH"
@@ -1339,11 +1352,21 @@ function kerl_deactivate --description "deactivate erlang environment"
         set --erase _KERL_MANPATH_REMOVABLE
     end
     if set --query _KERL_SAVED_REBAR_PLT_DIR
-        set -x REBAR_PLT_DIR "\$_KERL_SAVED_REBAR_PLT_DIR"
+        if set --query _KERL_REBAR_PLT_DIR_SET
+            set -x REBAR_PLT_DIR "\$_KERL_SAVED_REBAR_PLT_DIR"
+            set -e _KERL_REBAR_PLT_DIR_SET
+        else
+            set -e REBAR_PLT_DIR
+        end
         set --erase _KERL_SAVED_REBAR_PLT_DIR
     end
     if set --query _KERL_SAVED_REBAR_CACHE_DIR
-        set -x REBAR_CACHE_DIR "\$_KERL_SAVED_REBAR_CACHE_DIR"
+        if set --query _KERL_REBAR_CACHE_DIR_SET
+            set -x REBAR_CACHE_DIR "\$_KERL_SAVED_REBAR_CACHE_DIR"
+            set -e _KERL_REBAR_CACHE_DIR_SET
+        else
+            set -e REBAR_CACHE_DIR
+        end
         set --erase _KERL_SAVED_REBAR_CACHE_DIR
     end
     if set --query _KERL_ACTIVE_DIR
@@ -1381,7 +1404,9 @@ if test -n "\$_KERL_VERSION" -a "\$_KERL_VERSION" != "$KERL_VERSION"
   echo "         It was created with kerl $KERL_VERSION, and the current version is \$_KERL_VERSION."
 end
 
+set -q REBAR_CACHE_DIR && set -x _KERL_REBAR_CACHE_DIR_SET yes
 set -x _KERL_SAVED_REBAR_CACHE_DIR "\$REBAR_CACHE_DIR"
+set -q REBAR_PLT_DIR && set -x _KERL_REBAR_PLT_DIR_SET yes
 set -x _KERL_SAVED_REBAR_PLT_DIR "\$REBAR_PLT_DIR"
 set -x _KERL_PATH_REMOVABLE "$directory/bin"
 set -x PATH "\$_KERL_PATH_REMOVABLE" \$PATH
@@ -1420,7 +1445,25 @@ emit_activate_csh() {
 # This file must be used with "source bin/activate.csh" *from csh*.
 # You cannot run it directly.
 
-alias kerl_deactivate 'test \$?_KERL_SAVED_PATH != 0 && setenv PATH "\$_KERL_SAVED_PATH" && unset _KERL_SAVED_PATH; rehash; test \$?_KERL_SAVED_MANPATH != 0 && setenv MANPATH "\$_KERL_SAVED_MANPATH" && unset _KERL_SAVED_MANPATH; test \$?_KERL_SAVED_REBAR_PLT_DIR != 0 && setenv REBAR_PLT_DIR "\$_KERL_SAVED_REBAR_PLT_DIR" && unset _KERL_SAVED_REBAR_PLT_DIR; test \$?_KERL_SAVED_REBAR_CACHE_DIR != 0 && setenv REBAR_CACHE_DIR "\$_KERL_SAVED_REBAR_CACHE_DIR" && unset _KERL_SAVED_REBAR_CACHE_DIR; test \$?_KERL_ACTIVE_DIR != 0 && unset _KERL_ACTIVE_DIR; test \$?_KERL_ERL_CALL_REMOVABLE != 0 && unset _KERL_ERL_CALL_REMOVABLE; test \$?_KERL_SAVED_PROMPT != 0 && set prompt="\$_KERL_SAVED_PROMPT" && unset _KERL_SAVED_PROMPT; test "!:*" != "nondestructive" && unalias deactivate'
+alias kerl_deactivate '\\\\
+test \$?_KERL_PATH_REMOVABLE != 0 && unset _KERL_PATH_REMOVABLE; \\\\
+test \$?_KERL_MANPATH_REMOVABLE != 0 && unset _KERL_MANPATH_REMOVABLE; \\\\
+test \$?_KERL_SAVED_PATH != 0 && setenv PATH "\$_KERL_SAVED_PATH" && unset _KERL_SAVED_PATH; rehash; \\\\
+test \$?_KERL_SAVED_MANPATH != 0 && setenv MANPATH "\$_KERL_SAVED_MANPATH" && unset _KERL_SAVED_MANPATH; \\\\
+test \$?_KERL_REBAR_PLT_DIR_SET != 0 && test "\$_KERL_REBAR_PLT_DIR_SET" == "no" && \\\\
+unset _KERL_REBAR_PLT_DIR_SET && test \$?REBAR_PLT_DIR != 0 && unsetenv REBAR_PLT_DIR; \\\\
+test \$?_KERL_REBAR_PLT_DIR_SET != 0 && test "\$_KERL_REBAR_PLT_DIR_SET" == "yes" && \\\\
+unset _KERL_REBAR_PLT_DIR_SET && setenv REBAR_PLT_DIR "\$_KERL_SAVED_REBAR_PLT_DIR"; \\\\
+test \$?_KERL_SAVED_REBAR_PLT_DIR && unset _KERL_SAVED_REBAR_PLT_DIR; \\\\
+test \$?_KERL_REBAR_CACHE_DIR_SET != 0 && test "\$_KERL_REBAR_CACHE_DIR_SET" == "no" && \\\\
+unset _KERL_REBAR_CACHE_DIR_SET && test \$?REBAR_CACHE_DIR != 0 && unsetenv REBAR_CACHE_DIR; \\\\
+test \$?_KERL_REBAR_CACHE_DIR_SET != 0 && test "\$_KERL_REBAR_CACHE_DIR_SET" == "yes" && \\\\
+unset _KERL_REBAR_CACHE_DIR_SET && setenv REBAR_CACHE_DIR "\$_KERL_SAVED_REBAR_CACHE_DIR"; \\\\
+test \$?_KERL_SAVED_REBAR_CACHE_DIR && unset _KERL_SAVED_REBAR_CACHE_DIR; \\\\
+test \$?_KERL_ACTIVE_DIR != 0 && unset _KERL_ACTIVE_DIR; \\\\
+test \$?_KERL_ERL_CALL_REMOVABLE != 0 && unset _KERL_ERL_CALL_REMOVABLE; \\\\
+test \$?_KERL_SAVED_PROMPT != 0 && set prompt="\$_KERL_SAVED_PROMPT" && unset _KERL_SAVED_PROMPT; \\\\
+test "!:*" != "nondestructive" && unalias deactivate'
 
 # Unset irrelevant variables.
 kerl_deactivate nondestructive
@@ -1437,15 +1480,19 @@ if ("\$_KERL_VERSION" != "" && "\$_KERL_VERSION" != "$KERL_VERSION") then
 endif
 
 if ( \$?REBAR_CACHE_DIR ) then
+    set _KERL_REBAR_CACHE_DIR_SET = "yes"
     set _KERL_SAVED_REBAR_CACHE_DIR = "\$REBAR_CACHE_DIR"
 else
-    set _KERL_SAVED_REBAR_CACHE_DIR=""
+    set _KERL_REBAR_CACHE_DIR_SET = "no"
+    set _KERL_SAVED_REBAR_CACHE_DIR = ""
 endif
 
 if ( \$?REBAR_PLT_DIR ) then
+    set _KERL_REBAR_PLT_DIR_SET = "yes"
     set _KERL_SAVED_REBAR_PLT_DIR = "\$REBAR_PLT_DIR"
 else
-    set _KERL_SAVED_REBAR_PLT_DIR=""
+    set _KERL_REBAR_PLT_DIR_SET = "no"
+    set _KERL_SAVED_REBAR_PLT_DIR = ""
 endif
 
 set _KERL_PATH_REMOVABLE = "$directory/bin"

--- a/kerl
+++ b/kerl
@@ -1231,6 +1231,10 @@ kerl_deactivate() {
         REBAR_PLT_DIR="\$_KERL_SAVED_REBAR_PLT_DIR"
         unset _KERL_SAVED_REBAR_PLT_DIR
     fi
+    if [ -n "\$_KERL_SAVED_REBAR_CACHE_DIR" ]; then
+        REBAR_CACHE_DIR="\$_KERL_SAVED_REBAR_CACHE_DIR"
+        unset _KERL_SAVED_REBAR_CACHE_DIR
+    fi
     if [ -n "\$_KERL_ACTIVE_DIR" ]; then
         unset _KERL_ACTIVE_DIR
     fi
@@ -1267,11 +1271,13 @@ if [ -n "\$_KERL_VERSION" ] && [ "\$_KERL_VERSION" != "$KERL_VERSION" ]; then
 fi
 
 set -o allexport
+_KERL_SAVED_REBAR_CACHE_DIR="\$REBAR_CACHE_DIR"
 _KERL_SAVED_REBAR_PLT_DIR="\$REBAR_PLT_DIR"
 _KERL_PATH_REMOVABLE="$directory/bin"
 PATH="\${_KERL_PATH_REMOVABLE}:\$PATH"
 _KERL_MANPATH_REMOVABLE="$directory/lib/erlang/man:$directory/man"
 MANPATH="\${_KERL_MANPATH_REMOVABLE}:\$MANPATH"
+REBAR_CACHE_DIR="$directory/.cache/rebar3"
 REBAR_PLT_DIR="$directory"
 _KERL_ACTIVE_DIR="$directory"
 _KERL_ERL_CALL_REMOVABLE=\$(\\find $directory -type d -path "*erl_interface*/bin")
@@ -1336,6 +1342,10 @@ function kerl_deactivate --description "deactivate erlang environment"
         set -x REBAR_PLT_DIR "\$_KERL_SAVED_REBAR_PLT_DIR"
         set --erase _KERL_SAVED_REBAR_PLT_DIR
     end
+    if set --query _KERL_SAVED_REBAR_CACHE_DIR
+        set -x REBAR_CACHE_DIR "\$_KERL_SAVED_REBAR_CACHE_DIR"
+        set --erase _KERL_SAVED_REBAR_CACHE_DIR
+    end
     if set --query _KERL_ACTIVE_DIR
         set --erase _KERL_ACTIVE_DIR
     end
@@ -1371,11 +1381,13 @@ if test -n "\$_KERL_VERSION" -a "\$_KERL_VERSION" != "$KERL_VERSION"
   echo "         It was created with kerl $KERL_VERSION, and the current version is \$_KERL_VERSION."
 end
 
+set -x _KERL_SAVED_REBAR_CACHE_DIR "\$REBAR_CACHE_DIR"
 set -x _KERL_SAVED_REBAR_PLT_DIR "\$REBAR_PLT_DIR"
 set -x _KERL_PATH_REMOVABLE "$directory/bin"
 set -x PATH "\$_KERL_PATH_REMOVABLE" \$PATH
 set -x _KERL_MANPATH_REMOVABLE "$directory/lib/erlang/man" "$directory/man"
 set -x MANPATH \$MANPATH "\$_KERL_MANPATH_REMOVABLE"
+set -x REBAR_CACHE_DIR "$directory/.cache/rebar3"
 set -x REBAR_PLT_DIR "$directory"
 set -x _KERL_ACTIVE_DIR "$directory"
 set -x _KERL_ERL_CALL_REMOVABLE (find "$directory" -type d -path "*erl_interface*/bin")
@@ -1408,7 +1420,7 @@ emit_activate_csh() {
 # This file must be used with "source bin/activate.csh" *from csh*.
 # You cannot run it directly.
 
-alias kerl_deactivate 'test \$?_KERL_SAVED_PATH != 0 && setenv PATH "\$_KERL_SAVED_PATH" && unset _KERL_SAVED_PATH; rehash; test \$?_KERL_SAVED_MANPATH != 0 && setenv MANPATH "\$_KERL_SAVED_MANPATH" && unset _KERL_SAVED_MANPATH; test \$?_KERL_SAVED_REBAR_PLT_DIR != 0 && setenv REBAR_PLT_DIR "\$_KERL_SAVED_REBAR_PLT_DIR" && unset _KERL_SAVED_REBAR_PLT_DIR; test \$?_KERL_ACTIVE_DIR != 0 && unset _KERL_ACTIVE_DIR; test \$?_KERL_ERL_CALL_REMOVABLE != 0 && unset _KERL_ERL_CALL_REMOVABLE; test \$?_KERL_SAVED_PROMPT != 0 && set prompt="\$_KERL_SAVED_PROMPT" && unset _KERL_SAVED_PROMPT; test "!:*" != "nondestructive" && unalias deactivate'
+alias kerl_deactivate 'test \$?_KERL_SAVED_PATH != 0 && setenv PATH "\$_KERL_SAVED_PATH" && unset _KERL_SAVED_PATH; rehash; test \$?_KERL_SAVED_MANPATH != 0 && setenv MANPATH "\$_KERL_SAVED_MANPATH" && unset _KERL_SAVED_MANPATH; test \$?_KERL_SAVED_REBAR_PLT_DIR != 0 && setenv REBAR_PLT_DIR "\$_KERL_SAVED_REBAR_PLT_DIR" && unset _KERL_SAVED_REBAR_PLT_DIR; test \$?_KERL_SAVED_REBAR_CACHE_DIR != 0 && setenv REBAR_CACHE_DIR "\$_KERL_SAVED_REBAR_CACHE_DIR" && unset _KERL_SAVED_REBAR_CACHE_DIR; test \$?_KERL_ACTIVE_DIR != 0 && unset _KERL_ACTIVE_DIR; test \$?_KERL_ERL_CALL_REMOVABLE != 0 && unset _KERL_ERL_CALL_REMOVABLE; test \$?_KERL_SAVED_PROMPT != 0 && set prompt="\$_KERL_SAVED_PROMPT" && unset _KERL_SAVED_PROMPT; test "!:*" != "nondestructive" && unalias deactivate'
 
 # Unset irrelevant variables.
 kerl_deactivate nondestructive
@@ -1422,6 +1434,12 @@ endif
 if ("\$_KERL_VERSION" != "" && "\$_KERL_VERSION" != "$KERL_VERSION") then
   echo "WARNING: this Erlang/OTP installation appears to be stale. Please consider reinstalling."
   echo "         It was created with kerl $KERL_VERSION, and the current version is \$_KERL_VERSION."
+endif
+
+if ( \$?REBAR_CACHE_DIR ) then
+    set _KERL_SAVED_REBAR_CACHE_DIR = "\$REBAR_CACHE_DIR"
+else
+    set _KERL_SAVED_REBAR_CACHE_DIR=""
 endif
 
 if ( \$?REBAR_PLT_DIR ) then
@@ -1440,6 +1458,8 @@ endif
 set _KERL_MANPATH_REMOVABLE = "$directory/lib/erlang/man:$directory/man"
 set _KERL_SAVED_MANPATH = "\$MANPATH"
 setenv MANPATH "\${_KERL_MANPATH_REMOVABLE}:\$MANPATH"
+
+setenv REBAR_CACHE_DIR "$directory/.cache/rebar3"
 
 setenv REBAR_PLT_DIR "$directory"
 

--- a/kerl
+++ b/kerl
@@ -1280,6 +1280,8 @@ if [ -n "\$_KERL_VERSION" ] && [ "\$_KERL_VERSION" != "$KERL_VERSION" ]; then
   echo "         It was created with kerl $KERL_VERSION, and the current version is \$_KERL_VERSION."
 fi
 
+unset _KERL_VERSION _KERL
+
 set -o allexport
 _KERL_SAVED_REBAR_CACHE_DIR="\$REBAR_CACHE_DIR"
 _KERL_REBAR_CACHE_DIR_SET="\${REBAR_CACHE_DIR+x}"
@@ -1312,6 +1314,7 @@ if [ -n "\$KERL_ENABLE_PROMPT" ]; then
     fi
     _KERL_PRMPT=\$(echo "\$_KERL_PROMPT_FORMAT" | sed 's^%RELEASE%^$release^;s^%BUILDNAME%^$build_name^')
     PS1="\$_KERL_PRMPT\$PS1"
+    unset _KERL_PRMPT _KERL_PROMPT_FORMAT
 fi
 if [ -n "\$BASH" ] || [ -n "\$ZSH_VERSION" ]; then
     hash -r
@@ -1404,6 +1407,8 @@ if test -n "\$_KERL_VERSION" -a "\$_KERL_VERSION" != "$KERL_VERSION"
   echo "         It was created with kerl $KERL_VERSION, and the current version is \$_KERL_VERSION."
 end
 
+set -e _KERL_VERSION _KERL
+
 set -q REBAR_CACHE_DIR && set -x _KERL_REBAR_CACHE_DIR_SET yes
 set -x _KERL_SAVED_REBAR_CACHE_DIR "\$REBAR_CACHE_DIR"
 set -q REBAR_PLT_DIR && set -x _KERL_REBAR_PLT_DIR_SET yes
@@ -1478,6 +1483,8 @@ if ("\$_KERL_VERSION" != "" && "\$_KERL_VERSION" != "$KERL_VERSION") then
   echo "WARNING: this Erlang/OTP installation appears to be stale. Please consider reinstalling."
   echo "         It was created with kerl $KERL_VERSION, and the current version is \$_KERL_VERSION."
 endif
+
+unset _KERL_VERSION _KERL
 
 if ( \$?REBAR_CACHE_DIR ) then
     set _KERL_REBAR_CACHE_DIR_SET = "yes"

--- a/kerl
+++ b/kerl
@@ -1230,8 +1230,12 @@ kerl_deactivate() {
     if [ -n "\$_KERL_MANPATH_REMOVABLE" ]; then
         # shellcheck disable=SC2001
         MANPATH="\$(echo "\$MANPATH" | sed -e "s#\$_KERL_MANPATH_REMOVABLE:##")"
+        if [ -z "\$MANPATH" -a -z "\$_KERL_MANPATH_SET" ]; then
+            unset MANPATH
+        fi
         unset _KERL_MANPATH_REMOVABLE
     fi
+    unset _KERL_MANPATH_SET
     if [ -n "\${_KERL_REBAR_PLT_DIR_SET+x}" ]; then
         if [ -n "\$_KERL_REBAR_PLT_DIR_SET" ]; then
             REBAR_PLT_DIR="\$_KERL_SAVED_REBAR_PLT_DIR"
@@ -1295,6 +1299,7 @@ _KERL_REBAR_PLT_DIR_SET="\${REBAR_PLT_DIR+x}"
 _KERL_SAVED_REBAR_PLT_DIR="\$REBAR_PLT_DIR"
 _KERL_PATH_REMOVABLE="$directory/bin"
 PATH="\${_KERL_PATH_REMOVABLE}:\$PATH"
+_KERL_MANPATH_SET="\${MANPATH+x}"
 _KERL_MANPATH_REMOVABLE="$directory/lib/erlang/man:$directory/man"
 MANPATH="\${_KERL_MANPATH_REMOVABLE}:\$MANPATH"
 REBAR_CACHE_DIR="$directory/.cache/rebar3"

--- a/tests/activate_test.sh
+++ b/tests/activate_test.sh
@@ -1,9 +1,9 @@
 #!/bin/sh
 
-mod_env() {
+expected_env() {
     DIR="$1"
     OLD="$2"
-    cat "$OLD" |grep -wv -e PATH -e MANPATH -e PS1
+    grep "$OLD" -wv -e PATH -e MANPATH -e PS1
     cat - <<EOT
 _KERL_ACTIVE_DIR=$DIR
 _KERL_ERL_AFLAGS_SET=
@@ -19,7 +19,12 @@ PS1=$PS1
 REBAR_CACHE_DIR=$DIR/.cache/rebar3
 REBAR_PLT_DIR=$DIR
 EOT
-    ERLCALLDIR=`\find "$DIR" -type d -path "*erl_interface*/bin" 2>/dev/null`
+    if grep -qw MANPATH "$OLD"; then
+        echo "_KERL_MANPATH_SET=x"
+    else
+        echo "_KERL_MANPATH_SET="
+    fi
+    ERLCALLDIR=$(\find "$DIR" -type d -path "*erl_interface*/bin" 2>/dev/null)
     if [ -n "$ERLCALLDIR" ]; then
         echo "_KERL_ERL_CALL_REMOVABLE=$ERLCALLDIR"
         echo "PATH=$ERLCALLDIR:$DIR/bin:$PATH"
@@ -33,20 +38,21 @@ test_it() {
     ./kerl emit-activate "$1" "$1" "$2" >/tmp/activate.sh
     export PS1="test> "
     env | sort >/tmp/env_old
+    # shellcheck source=/dev/null
     . /tmp/activate.sh
     env | sort >/tmp/env_act
     kerl_deactivate
     env | sort >/tmp/env_new
 
-    mod_env $2 /tmp/env_old | sort >/tmp/env_mod
-    diff /tmp/env_mod /tmp/env_act || { echo "env setup failed"; exit 1; }
+    expected_env "$2" /tmp/env_old | sort >/tmp/env_exp
+    diff /tmp/env_exp /tmp/env_act || { echo "env setup failed"; exit 1; }
     diff /tmp/env_old /tmp/env_new || { echo "env cleanup failed"; exit 1; }
 }
 
 ver=$1
 
-existing_dir=`./kerl path "$ver"`
-[ -d "$existing_dir" ] || exit -1
+existing_dir=$(./kerl path "$ver")
+[ -d "$existing_dir" ] || exit 1
 
 test_it "$ver" "$existing_dir"
 test_it foo foo_dir

--- a/tests/activate_test.sh
+++ b/tests/activate_test.sh
@@ -1,0 +1,52 @@
+#!/bin/sh -e
+
+mod_env() {
+    DIR="$1"
+    OLD="$2"
+    cat "$OLD" |grep -wv -e PATH -e MANPATH -e PS1
+    cat - <<EOT
+_KERL_ACTIVE_DIR=$DIR
+_KERL_ERL_AFLAGS_SET=
+_KERL_MANPATH_REMOVABLE=$DIR/lib/erlang/man:$DIR/man
+_KERL_PATH_REMOVABLE=$DIR/bin
+_KERL_REBAR_CACHE_DIR_SET=
+_KERL_REBAR_PLT_DIR_SET=
+_KERL_SAVED_REBAR_CACHE_DIR=
+_KERL_SAVED_REBAR_PLT_DIR=
+ERL_AFLAGS=-kernel shell_history enabled
+MANPATH=$DIR/lib/erlang/man:$DIR/man:$MANPATH
+PS1=$PS1
+REBAR_CACHE_DIR=$DIR/.cache/rebar3
+REBAR_PLT_DIR=$DIR
+EOT
+    ERLCALLDIR=`\find "$DIR" -type d -path "*erl_interface*/bin" 2>/dev/null`
+    if [ -n "$ERLCALLDIR" ]; then
+        echo "_KERL_ERL_CALL_REMOVABLE=$ERLCALLDIR"
+        echo "PATH=$ERLCALLDIR:$DIR/bin:$PATH"
+    else
+        echo "_KERL_ERL_CALL_REMOVABLE="
+        echo "PATH=$DIR/bin:$PATH"
+    fi
+}
+
+test_it() {
+    ./kerl emit-activate "$1" "$1" "$2" >/tmp/activate.sh
+    export PS1="test> "
+    env | sort >/tmp/env_old
+    . /tmp/activate.sh
+    env | sort >/tmp/env_act
+    kerl_deactivate
+    env | sort >/tmp/env_new
+
+    mod_env $2 /tmp/env_old | sort >/tmp/env_mod
+    diff /tmp/env_mod /tmp/env_act || { echo "env setup failed"; exit -1; }
+    diff /tmp/env_old /tmp/env_new || { echo "env cleanup failed"; exit -1; }
+}
+
+ver=$1
+
+existing_dir=`./kerl path "$ver"`
+[ -d "$existing_dir" ] || exit -1
+
+test_it "$ver" "$existing_dir"
+test_it foo foo_dir

--- a/tests/activate_test.sh
+++ b/tests/activate_test.sh
@@ -35,7 +35,10 @@ EOT
 }
 
 test_it() {
-    ./kerl emit-activate "$1" "$1" "$2" >/tmp/activate.sh
+    release=$1
+    build_name=$2
+    directory=$3
+    ./kerl emit-activate "$release" "$build_name" "$directory" >/tmp/activate.sh
     export PS1="test> "
     env | sort >/tmp/env_old
     # shellcheck source=/dev/null
@@ -44,15 +47,16 @@ test_it() {
     kerl_deactivate
     env | sort >/tmp/env_new
 
-    expected_env "$2" /tmp/env_old | sort >/tmp/env_exp
+    expected_env "$directory" /tmp/env_old | sort >/tmp/env_exp
     diff /tmp/env_exp /tmp/env_act || { echo "env setup failed"; exit 1; }
     diff /tmp/env_old /tmp/env_new || { echo "env cleanup failed"; exit 1; }
 }
 
-ver=$1
+release=$1
+build_name=$2
+directory=$3
 
-existing_dir=$(./kerl path "$ver")
-[ -d "$existing_dir" ] || exit 1
+[ -d "$directory" ] || exit 1
 
-test_it "$ver" "$existing_dir"
-test_it foo foo_dir
+test_it "$release" "$build_name" "$directory"
+test_it foo boo foo_dir

--- a/tests/activate_test.sh
+++ b/tests/activate_test.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -e
+#!/bin/sh
 
 mod_env() {
     DIR="$1"
@@ -39,8 +39,8 @@ test_it() {
     env | sort >/tmp/env_new
 
     mod_env $2 /tmp/env_old | sort >/tmp/env_mod
-    diff /tmp/env_mod /tmp/env_act || { echo "env setup failed"; exit -1; }
-    diff /tmp/env_old /tmp/env_new || { echo "env cleanup failed"; exit -1; }
+    diff /tmp/env_mod /tmp/env_act || { echo "env setup failed"; exit 1; }
+    diff /tmp/env_old /tmp/env_new || { echo "env cleanup failed"; exit 1; }
 }
 
 ver=$1


### PR DESCRIPTION
The REBAR_CACHE_DIR should be separated between releases to avoid unexpected dialyzer errors caused by cached files from previous "rebar3 dialyzer" runs.
By default rebar3 uses ~/.cache/rebar3, this caused problems in different kerl environments.

# Description

Handling of the REBAR_CACHE_DIR variable was added the same way as it was done for REBAR_PLT_DIR.

Closes #&lt;issue&gt;.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/kerl/kerl/blob/main/CONTRIBUTING.md)
