### PR TITLE
shellcheck and shfmt generated files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
           if [[ ${{matrix.os}} == macos* ]]; then
             /bin/bash -c "$(curl -fsSL \
               https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-            brew install automake fop wxwidgets fish shellcheck
+            brew install automake fop wxwidgets fish shellcheck shfmt
           else
             sudo sed -i 's/azure\.//' /etc/apt/sources.list # Reduces chance of time-outs
             sudo apt-get update -y
@@ -26,7 +26,8 @@ jobs:
             sudo apt-get install -y --no-install-recommends \
               git curl libssl-dev make automake autoconf libncurses5-dev gcc g++ default-jdk \
               unixodbc-dev libwxgtk3.0-gtk3-dev libwxgtk-webview3.0-gtk3-dev xsltproc fop \
-              libxml2-utils libsctp-dev lksctp-tools software-properties-common shellcheck
+              libxml2-utils libsctp-dev lksctp-tools software-properties-common shellcheck \
+              shfmt
             sudo apt-add-repository -y ppa:fish-shell/release-3
             sudo apt-get update -y
             sudo apt-get install -y --no-install-recommends fish
@@ -92,6 +93,7 @@ jobs:
           ./kerl emit-activate $_KERL_REL $_KERL_VSN $(./kerl path install_"$_KERL_VSN") > activate-new
           diff activate-new $(./kerl path install_"$_KERL_VSN")/activate
           shellcheck -o all activate-new
+          shfmt -i 4 -d activate-new
           rm -f activate-new
       - name: Test emit-activate (fish)
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
           if [[ ${{matrix.os}} == macos* ]]; then
             /bin/bash -c "$(curl -fsSL \
               https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-            brew install automake fop wxwidgets fish
+            brew install automake fop wxwidgets fish shellcheck
           else
             sudo sed -i 's/azure\.//' /etc/apt/sources.list # Reduces chance of time-outs
             sudo apt-get update -y
@@ -26,7 +26,7 @@ jobs:
             sudo apt-get install -y --no-install-recommends \
               git curl libssl-dev make automake autoconf libncurses5-dev gcc g++ default-jdk \
               unixodbc-dev libwxgtk3.0-gtk3-dev libwxgtk-webview3.0-gtk3-dev xsltproc fop \
-              libxml2-utils libsctp-dev lksctp-tools software-properties-common
+              libxml2-utils libsctp-dev lksctp-tools software-properties-common shellcheck
             sudo apt-add-repository -y ppa:fish-shell/release-3
             sudo apt-get update -y
             sudo apt-get install -y --no-install-recommends fish
@@ -91,6 +91,7 @@ jobs:
         run: |
           ./kerl emit-activate $_KERL_REL $_KERL_VSN $(./kerl path install_"$_KERL_VSN") > activate-new
           diff activate-new $(./kerl path install_"$_KERL_VSN")/activate
+          shellcheck -o all activate-new
           rm -f activate-new
       - name: Test emit-activate (fish)
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,10 +12,7 @@ jobs:
         uses: luizm/action-sh-checker@v0.7.0
         env:
           SHELLCHECK_OPTS: -o all
-          SHFMT_OPTS: -i 4
-      - name: Check push (shfmt)
-        run: |
-          git diff --exit-code
+          SHFMT_OPTS: -i 4 -d
       # uses .markdownlint.yml for configuration
       - name: Run markdownlint
         uses: DavidAnson/markdownlint-cli2-action@v10

--- a/kerl
+++ b/kerl
@@ -1210,6 +1210,9 @@ emit_activate() {
     cat << \
         =======
 #!/bin/sh
+
+# shellcheck disable=SC2250  # Prefer putting braces around variable references even when not strictly required
+
 if type kerl_deactivate 2>/dev/null | \grep -qw function; then
     kerl_deactivate
 fi

--- a/kerl
+++ b/kerl
@@ -1219,20 +1219,20 @@ fi
 
 _KERL=$(command -v kerl)
 if [ -n "\$_KERL" ]; then
-  _KERL_VERSION=\$(\$_KERL version)
+    _KERL_VERSION=\$(\$_KERL version)
 fi
 if [ -n "\$_KERL_VERSION" ] && [ "\$_KERL_VERSION" != "$KERL_VERSION" ]; then
-  echo "WARNING: this Erlang/OTP installation appears to be stale. Please consider reinstalling."
-  echo "         It was created with kerl $KERL_VERSION, and the current version is \$_KERL_VERSION."
+    echo "WARNING: this Erlang/OTP installation appears to be stale. Please consider reinstalling."
+    echo "         It was created with kerl $KERL_VERSION, and the current version is \$_KERL_VERSION."
 fi
 unset _KERL_VERSION
 unset _KERL
 
 add_cleanup() {
-  _KERL_CLEANUP="
+    _KERL_CLEANUP="
     \$1
     \$_KERL_CLEANUP
-  "
+    "
 }
 
 set -o allexport


### PR DESCRIPTION
# Description

This is just making sure our generated files are `shellcheck`'ed and `shfmt`'ed. If we see this is an impediment to future pull requests we can revert it.

Closes #462.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/kerl/kerl/blob/main/CONTRIBUTING.md)
