### PR TITLE
Fix/improve output on errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 'on': [push, pull_request]
 env:
   ERLC_USE_SERVER: true
-  KERL_DEBUG: yes
+  KERL_DEBUG: 'yes'
 jobs:
   ci:
     name: CI OTP ${{matrix.otp_vsn}}, on ${{matrix.os}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,9 @@ jobs:
           erl -s crypto -s init stop
           erl_call
       - name: Check installation status (post- activation)
-        run: ./kerl status
+        run: |
+          source $(./kerl path install_"$_KERL_VSN")/activate
+          ./kerl status
       - name: Test KERL_RELEASE_TARGET
         # yamllint disable rule:line-length
         run: |
@@ -142,4 +144,6 @@ jobs:
           erl -s crypto -s init stop
           erl_call
       - name: Check installation status (post- activation)
-        run: ./kerl status
+        run: |
+          source $(./kerl path build-install_"${_KERL_VSN}")/activate
+          ./kerl status

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,13 +72,15 @@ jobs:
         # yamllint disable rule:line-length
       - name: Install chosen version
         run: ./kerl install "$_KERL_VSN" "install_$_KERL_VSN"
-      - name: Check installation status
-        run: ./kerl status
+      - name: Check installation status (pre- activation)
+        run: ./kerl status || exit 0
       - name: Validate installation
         run: |
           source $(./kerl path install_"$_KERL_VSN")/activate
           erl -s crypto -s init stop
           erl_call
+      - name: Check installation status (post- activation)
+        run: ./kerl status
       - name: Test KERL_RELEASE_TARGET
         # yamllint disable rule:line-length
         run: |
@@ -132,10 +134,12 @@ jobs:
             cat ~/.kerl/builds/*/*.log
             exit 1
           fi
-      - name: Check installation status (build+install)
-        run: ./kerl status
+      - name: Check installation status (pre- activation)
+        run: ./kerl status || exit 0
       - name: Validate installation (build+install)
         run: |
           source $(./kerl path build-install_"${_KERL_VSN}")/activate
           erl -s crypto -s init stop
           erl_call
+      - name: Check installation status (post- activation)
+        run: ./kerl status

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: CI
 'on': [push, pull_request]
 env:
   ERLC_USE_SERVER: true
+  KERL_DEBUG: yes
 jobs:
   ci:
     name: CI OTP ${{matrix.otp_vsn}}, on ${{matrix.os}}
@@ -60,17 +61,17 @@ jobs:
         run: |
           echo "OpenSSL is $(openssl version)"
           export MAKEFLAGS=-j$(($(nproc) + 2))
-          if ! KERL_DEBUG=yes ./kerl build ${_KERL_PREFIX_GIT} \
-                                           ${_KERL_PREFIX_GIT_TARGET} \
-                                          "${_KERL_VSN}" \
-                                          "${_KERL_VSN}"; then
+          if ! ./kerl build ${_KERL_PREFIX_GIT} \
+                            ${_KERL_PREFIX_GIT_TARGET} \
+                           "${_KERL_VSN}" \
+                           "${_KERL_VSN}"; then
             ## Print build log if it fails
             cat ~/.kerl/builds/*/*.log
             exit 1
           fi
         # yamllint disable rule:line-length
       - name: Install chosen version
-        run: KERL_DEBUG=yes ./kerl install "$_KERL_VSN" "install_$_KERL_VSN"
+        run: ./kerl install "$_KERL_VSN" "install_$_KERL_VSN"
       - name: Check installation status
         run: ./kerl status
       - name: Validate installation
@@ -122,11 +123,11 @@ jobs:
       - name: Test build+install chosen version
         run: |
           export MAKEFLAGS="-j$(getconf _NPROCESSORS_ONLN)"
-          if ! KERL_DEBUG=yes ./kerl build-install ${_KERL_PREFIX_GIT} \
-                                                   ${_KERL_PREFIX_GIT_TARGET} \
-                                                  "${_KERL_VSN}" \
-                                                  "${_KERL_VSN}" \
-                                                  "$PWD/build-install_${_KERL_VSN}"; then
+          if ! ./kerl build-install ${_KERL_PREFIX_GIT} \
+                                    ${_KERL_PREFIX_GIT_TARGET} \
+                                   "${_KERL_VSN}" \
+                                   "${_KERL_VSN}" \
+                                   "$PWD/build-install_${_KERL_VSN}"; then
             ## Print build log if it fails
             cat ~/.kerl/builds/*/*.log
             exit 1

--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ The available releases are:
 26.0.2 *
 ```
 
-**Note**: this list, kept in a file managed by Kerl, is different depending on the build backend
+**Note**: this list, kept in a file managed by `kerl`, is different depending on the build backend
 you use.
 
 From here (provided the `KERL_BUILD_BACKEND` and `OTP_GITHUB_URL` variables remain in place), it is
@@ -362,7 +362,7 @@ Directory in which `kerl` will clone Git repositories for building.
 #### `KERL_CHECK_BUILD_PACKAGES`
 
 Default: yes (Enabled)
-Kerl will try to probe your Linux distro for build-required packages logging
+`kerl` will try to probe your Linux distro for build-required packages logging
 where the probes fail. You can turn off this behaviour by setting the
 environment variable to something other than "yes".
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,6 @@ You can also install directly from a raw Git repository by using the
 
 List the available releases:
 
-<!-- markdownlint-disable MD007 # line-length -->
 ```console
 $ kerl list releases
 17.5.6.10
@@ -103,7 +102,6 @@ Run './kerl update releases' to update this list.
 Run './kerl list releases all' to view all available releases.
 Note: * means "currently supported".
 ```
-<!-- markdownlint-enable MD007 # line-length -->
 
 Pick your choice and build it:
 
@@ -257,11 +255,11 @@ $ kerl_deactivate
 It is possible to build Erlang/OTP from a GitHub fork, by using the `KERL_BUILD_BACKEND=git` and
 setting `OTP_GITHUB_URL` to the URL of the fork. For example, to build `<orgname>'s` Erlang/OTP fork:
 
-<!-- markdownlint-disable MD007 # line-length -->
 ```console
 $ export KERL_BUILD_BACKEND=git
 $ export OTP_GITHUB_URL='https://github.com/<orgname>/otp'
 $ KERL_INCLUDE_RELEASE_CANDIDATES=yes kerl update releases
+Getting releases from GitHub...
 The available releases are:
 24.0-rc1 *
 24.0-rc1.1-orgname *
@@ -276,7 +274,9 @@ The available releases are:
 ...
 26.0.2 *
 ```
-<!-- markdownlint-enable MD007 # line-length -->
+
+**Note**: this list, kept in a file managed by Kerl, is different depending on the build backend
+you use.
 
 From here (provided the `KERL_BUILD_BACKEND` and `OTP_GITHUB_URL` variables remain in place), it is
 possible to use `kerl` as before:

--- a/kerl
+++ b/kerl
@@ -570,21 +570,6 @@ is_valid_release() {
     return 1
 }
 
-assert_valid_release() {
-    if ! is_valid_release "$1"; then
-        error "'$1' is not a valid Erlang/OTP release."
-        return 1
-    fi
-}
-
-assert_valid_install_path() {
-    # $1: directory
-
-    if ! is_valid_install_path "$1"; then
-        return 1
-    fi
-}
-
 get_release_from_name() {
     if [ -f "$KERL_BASE_DIR"/otp_builds ]; then
         while read -r l; do
@@ -614,23 +599,16 @@ is_valid_installation() {
     return 1
 }
 
-assert_valid_installation() {
-    if ! is_valid_installation "$1"; then
-        error "'$1' is not a kerl-managed Erlang/OTP installation."
-        exit 1
-    fi
-}
-
-assert_build_name_unused() {
+is_build_name_used() {
     if [ -f "$KERL_BASE_DIR"/otp_builds ]; then
         while read -r l; do
             name=$(echo "$l" | cut -d, -f2)
             if [ "$name" = "$1" ]; then
-                error "there's already a build named '$1'."
-                return 1
+                return 0
             fi
         done <"$KERL_BASE_DIR"/otp_builds
     fi
+    return 1
 }
 
 is_older_than_x_days() {
@@ -842,10 +820,11 @@ do_normal_build() {
     # $1: release
     # $2: build name
 
-    if ! assert_valid_release "$1"; then
+    if ! is_valid_release "$1"; then
         exit_build
     fi
-    if ! assert_build_name_unused "$2"; then
+    if is_build_name_used "$2"; then
+        error "there's already a build named '$2'."
         exit_build
     fi
 
@@ -1649,7 +1628,7 @@ unset _KERL_CLEANUP
 do_install() {
     build_name=$1
 
-    if ! assert_valid_install_path "$2"; then
+    if ! is_valid_install_path "$2"; then
         exit_install
     fi
 
@@ -1845,7 +1824,10 @@ do_deploy() {
     fi
     host="$1"
 
-    assert_valid_installation "$2"
+    if ! is_valid_installation "$2"; then
+        error "'$2' is not a kerl-managed Erlang/OTP installation."
+        exit 1
+    fi
     rel="$(get_name_from_install_path "$2")"
     path="$2"
     remotepath="$path"
@@ -2459,7 +2441,9 @@ delete)
             usage_exit "delete installation <directory>"
         fi
 
-        assert_valid_installation "$3"
+        if ! is_valid_install_path "$1"; then
+            exit 1
+        fi
         if [ -d "$3" ]; then
             maybe_remove "$3"
         else

--- a/kerl
+++ b/kerl
@@ -559,9 +559,9 @@ ensure_checksum_file() {
 }
 
 check_releases() {
-    # $1: force? (if true, the list is always recreated)
+    # $1: force?: if force, the list is always recreated
 
-    if [ "$1" = true ]; then
+    if [ "$1" = force ]; then
         rm -f "${KERL_BASE_DIR:?}"/otp_releases
     fi
     if [ ! -f "$KERL_BASE_DIR"/otp_releases ] &&
@@ -2313,7 +2313,7 @@ update)
         usage_exit "update releases"
     fi
 
-    if ! check_releases true; then
+    if ! check_releases force; then
         exit 1
     else
         notice "The available releases are:"

--- a/kerl
+++ b/kerl
@@ -505,7 +505,7 @@ get_git_releases() {
         return 0
     else
         rm -f "$tmp"
-        error "failed: git ls-remote --tags --refs $OTP_GITHUB_URL returned $ret!"
+        error "git ls-remote --tags --refs $OTP_GITHUB_URL returned $ret!"
         return 1
     fi
 }
@@ -542,7 +542,7 @@ get_tarball_releases() {
         return 0
     else
         rm -f "$tmp"
-        error "failed: _curl $ERLANG_DOWNLOAD_URL returned $http_code!"
+        error "_curl $ERLANG_DOWNLOAD_URL returned $http_code!"
         return 1
     fi
 }
@@ -552,7 +552,7 @@ update_checksum_file() {
         notice "Getting checksum file from erlang.org..."
         http_code=$(_curl "$KERL_DOWNLOAD_DIR"/MD5 "$ERLANG_DOWNLOAD_URL"/MD5)
         if [ 200 != "$http_code" ]; then
-            error "failed: _curl $ERLANG_DOWNLOAD_URL/MD5 returned $http_code!"
+            error "_curl $ERLANG_DOWNLOAD_URL/MD5 returned $http_code!"
             return 1
         fi
     fi
@@ -2185,7 +2185,7 @@ github_download() {
         notice "Downloading (from GitHub) Erlang/OTP $1 to $KERL_DOWNLOAD_DIR..."
         http_code=$(_curl "$tarball_file" "$tarball_url")
         if [ 200 != "$http_code" ]; then
-            error "failed: _curl $tarball_url returned $http_code!"
+            error "_curl $tarball_url returned $http_code!"
             return 1
         fi
     else
@@ -2196,7 +2196,7 @@ github_download() {
             rm -rf "$tarball_file"
             http_code=$(_curl "$tarball_file" "$tarball_url")
             if [ 200 != "$http_code" ]; then
-                error "failed: _curl $tarball_url returned $http_code!"
+                error "_curl $tarball_url returned $http_code!"
                 return 1
             fi
         fi
@@ -2208,7 +2208,7 @@ tarball_download() {
         notice "Downloading tarball $1 to $KERL_DOWNLOAD_DIR..."
         http_code=$(_curl "$KERL_DOWNLOAD_DIR/$1" "$ERLANG_DOWNLOAD_URL/$1")
         if [ 200 != "$http_code" ]; then
-            error "failed: _curl $ERLANG_DOWNLOAD_URL/$1 returned $http_code!"
+            error "_curl $ERLANG_DOWNLOAD_URL/$1 returned $http_code!"
             return 1
         fi
         if ! update_checksum_file; then
@@ -2232,7 +2232,7 @@ upgrade_kerl() {
     install_folder=$1
     http_code=$(_curl "$install_folder/kerl" "$KERL_GIT_BASE"/kerl)
     if [ 200 != "$http_code" ]; then
-        error "failed: _curl $KERL_GIT_BASE/kerl returned $http_code!"
+        error "_curl $KERL_GIT_BASE/kerl returned $http_code!"
         return 1
     fi
     chmod +x "$install_folder/kerl"
@@ -2624,7 +2624,7 @@ emit-activate)
     esac
     ;;
 *)
-    error "unknown command: '$1'."
+    error "unknown command '$1'."
     k_usage
     ;;
 esac

--- a/kerl
+++ b/kerl
@@ -1025,6 +1025,22 @@ probe_pkgs() {
     fi
 }
 
+fail_do_build() {
+    # $1: error message
+    # $2: build name
+    # $3: release
+
+    show_build_logfile "$1"
+
+    if [ -n "$2" ]; then
+        autoclean "$2"
+    fi
+
+    if [ -n "$3" ]; then
+        list_remove builds "$3 $2"
+    fi
+}
+
 _do_build() {
     init_build_logfile "$1" "$2"
     log_build_entry "*** $(date) - kerl build $1 ***"
@@ -1068,7 +1084,7 @@ _do_build() {
 
     ERL_TOP="$KERL_BUILD_DIR/$2/otp_src_$1"
     if ! cd "$ERL_TOP"; then
-        error "couldn't cd into $ERL_TOP"
+        fail_do_build "couldn't cd into $ERL_TOP"
         return 1
     fi
 
@@ -1131,15 +1147,13 @@ _do_build() {
     if [ -n "$KERL_USE_AUTOCONF" ]; then
         # shellcheck disable=SC2086  # Double quote to prevent globbing and word splitting
         if ! log_build_cmd "./otp_build autoconf && _flags ./otp_build configure $KERL_CONFIGURE_OPTIONS"; then
-            show_build_logfile "configure failed."
-            list_remove builds "$1 $2"
+            fail_do_build "configure failed." "$2" "$1"
             return 1
         fi
     else
         # shellcheck disable=SC2086  # Double quote to prevent globbing and word splitting
         if ! log_build_cmd "_flags ./otp_build configure $KERL_CONFIGURE_OPTIONS"; then
-            show_build_logfile "configure failed."
-            list_remove builds "$1 $2"
+            fail_do_build "configure failed." "$2" "$1"
             return 1
         fi
 
@@ -1148,9 +1162,7 @@ _do_build() {
         log_build_cmd "make clean"
         # shellcheck disable=SC2086  # Double quote to prevent globbing and word splitting
         if ! log_build_cmd "_flags ./otp_build configure $KERL_CONFIGURE_OPTIONS"; then
-            show_build_logfile "configure failed."
-            list_remove builds "$1 $2"
-            autoclean "$2"
+            fail_do_build "configure failed." "$2" "$1"
             return 1
         fi
     fi
@@ -1165,9 +1177,7 @@ _do_build() {
         \find ./lib -maxdepth 1 -type d -exec touch -f {}/SKIP \;
         for app in $KERL_CONFIGURE_APPLICATIONS; do
             if ! rm ./lib/"$app"/SKIP; then
-                error "couldn't prepare '$app' application for building."
-                list_remove builds "$1 $2"
-                autoclean "$2"
+                fail_do_build "couldn't prepare '$app' application for building." "$2" "$1"
                 return 1
             fi
         done
@@ -1175,7 +1185,7 @@ _do_build() {
     if [ -n "$KERL_CONFIGURE_DISABLE_APPLICATIONS" ]; then
         for app in $KERL_CONFIGURE_DISABLE_APPLICATIONS; do
             if ! touch -f ./lib/"$app"/SKIP; then
-                error "couldn't disable '$app' application for building."
+                fail_do_build "couldn't disable '$app' application for building." "$2" "$1"
                 return 1
             fi
         done
@@ -1183,24 +1193,18 @@ _do_build() {
 
     # shellcheck disable=SC2086  # Double quote to prevent globbing and word splitting
     if ! log_build_cmd "_flags ./otp_build boot -a $KERL_CONFIGURE_OPTIONS"; then
-        show_build_logfile "build failed."
-        list_remove builds "$1 $2"
-        autoclean "$2"
+        fail_do_build "build failed." "$2" "$1"
         return 1
     fi
     if [ -n "$KERL_BUILD_DOCS" ]; then
         notice "Building docs..."
         release=$(get_otp_version "$2")
         if ! log_build_cmd "make docs DOC_TARGETS=$KERL_DOC_TARGETS"; then
-            show_build_logfile "building docs failed."
-            list_remove builds "$1 $2"
-            autoclean "$2"
+            fail_do_build "building docs failed." "$2" "$1"
             return 1
         fi
         if ! log_build_cmd "make release_docs DOC_TARGETS=$KERL_DOC_TARGETS RELEASE_ROOT=$KERL_BUILD_DIR/$2/release_$1"; then
-            show_build_logfile "release of docs failed."
-            list_remove builds "$1 $2"
-            autoclean "$2"
+            fail_do_build "release of docs failed." "$2" "$1"
             return 1
         fi
     fi
@@ -1212,24 +1216,22 @@ _do_build() {
             opt | debug)
                 notice "Also building for Erlang/OTP $1 ($2) $r_type VM; please wait..."
                 if ! cd "$ERL_TOP"; then
-                    error "couldn't cd into $ERL_TOP"
+                    fail_do_build "couldn't cd into $ERL_TOP" "$2" "$1"
                     return 1
                 fi
                 if ! log_build_cmd "make TYPE=$r_type ERL_TOP=$ERL_TOP"; then
-                    show_build_logfile "build of '$r_type' VM failed."
-                    list_remove builds "$1 $2"
+                    fail_do_build "build of '$r_type' VM failed." "$2" "$1"
                     return 1
                 fi
                 ;;
             gcov | gprof | valgrind | asan | lcnt)
                 notice "Also building for Erlang/OTP $1 ($2) $r_type VM; please wait..."
                 if ! cd "$ERL_TOP/erts/emulator"; then
-                    error "couldn't cd into $ERL_TOP/erts/emulator"
+                    fail_do_build "couldn't cd into $ERL_TOP/erts/emulator" "$2" "$1"
                     return 1
                 fi
                 if ! log_build_cmd "make $r_type ERL_TOP=$ERL_TOP"; then
-                    show_build_logfile "build of '$r_type' VM failed."
-                    list_remove builds "$1 $2"
+                    fail_do_build "build of '$r_type' VM failed." "$2" "$1"
                     return 1
                 fi
                 ;;

--- a/kerl
+++ b/kerl
@@ -498,7 +498,7 @@ get_git_releases() {
             LC_ALL=C sort -n |
             cut -d':' -f2- |
             tee "$1" >/dev/null 2>&1; then
-            error "file $1 does not appear to be writable"
+            error "file $1 does not appear to be writable."
             return 1
         fi
         rm -f "$tmp"
@@ -535,7 +535,7 @@ get_tarball_releases() {
             sort |
             cut -d: -f2 |
             tee "$1" >/dev/null 2>&1; then
-            error "file $1 does not appear to be writable"
+            error "file $1 does not appear to be writable."
             return 1
         fi
         rm -f "$tmp"
@@ -552,7 +552,7 @@ update_checksum_file() {
         notice "Getting checksum file from erlang.org..."
         http_code=$(_curl "$KERL_DOWNLOAD_DIR"/MD5 "$ERLANG_DOWNLOAD_URL"/MD5)
         if [ 200 != "$http_code" ]; then
-            error "failed: _curl $ERLANG_DOWNLOAD_URL/MD5 returned $http_code"
+            error "failed: _curl $ERLANG_DOWNLOAD_URL/MD5 returned $http_code!"
             return 1
         fi
     fi
@@ -569,7 +569,7 @@ check_releases() {
 
     if [ "$1" = force ]; then
         if ! rm -f "${KERL_BASE_DIR:?}"/otp_releases 2>/dev/null; then
-            error "${KERL_BASE_DIR:?}/otp_releases cannot be removed"
+            error "${KERL_BASE_DIR:?}/otp_releases cannot be removed."
             return 1
         fi
     fi
@@ -1712,7 +1712,7 @@ do_install() {
 
     if [ -n "$KERL_BUILD_DOCS" ]; then
         if ! cd "$ERL_TOP"; then
-            error "couldn't cd into $ERL_TOP"
+            error "couldn't cd into $ERL_TOP."
             exit_install
         fi
         if ! log_install_cmd "ERL_TOP=$ERL_TOP make release_docs DOC_TARGETS=$KERL_DOC_TARGETS RELEASE_ROOT=$absdir"; then
@@ -1800,7 +1800,7 @@ download_htmldocs() {
 build_plt() {
     dialyzerd="$1"/dialyzer
     if ! mkdir -p "$dialyzerd"; then
-        error "couldn't create folder $dialyzerd"
+        error "couldn't create folder $dialyzerd."
         return 1
     fi
     plt="$dialyzerd"/plt
@@ -1832,7 +1832,7 @@ do_plt() {
             return 1
         fi
     else
-        error "no Erlang/OTP installation is currently active"
+        error "no Erlang/OTP installation is currently active."
         return 1
     fi
 }
@@ -2098,12 +2098,12 @@ list_add() {
             fi
         done <"$KERL_BASE_DIR/otp_$1"
         if ! echo "$2" | tee -a "$KERL_BASE_DIR/otp_$1" >/dev/null 2>&1; then
-            error "file $KERL_BASE_DIR/otp_$1 does not appear to be writable"
+            error "file $KERL_BASE_DIR/otp_$1 does not appear to be writable."
             return 1
         fi
     else
         if ! echo "$2" | tee "$KERL_BASE_DIR/otp_$1" >/dev/null 2>&1; then
-            error "file $KERL_BASE_DIR/otp_$1 does not appear to be writable"
+            error "file $KERL_BASE_DIR/otp_$1 does not appear to be writable."
             return 1
         fi
     fi
@@ -2112,7 +2112,7 @@ list_add() {
 list_remove() {
     if [ -f "$KERL_BASE_DIR/otp_$1" ]; then
         if ! sed "$SED_OPT" -i -e "/^.*$2$/d" "$KERL_BASE_DIR/otp_$1" 2>/dev/null; then
-            error "file $KERL_BASE_DIR/otp_$1 does not appear writable"
+            error "file $KERL_BASE_DIR/otp_$1 does not appear writable."
             return 1
         fi
     fi
@@ -2143,7 +2143,7 @@ do_active() {
         echo "$ACTIVE_PATH"
         return 0
     else
-        error "no Erlang/OTP installation is currently active"
+        error "no Erlang/OTP installation is currently active."
         return 1
     fi
 }
@@ -2155,7 +2155,7 @@ make_filename() {
 
 download() {
     if ! mkdir -p "$KERL_DOWNLOAD_DIR"; then
-        error "couldn't create folder $KERL_DOWNLOAD_DIR"
+        error "couldn't create folder $KERL_DOWNLOAD_DIR."
         return 1
     fi
     if [ "$KERL_BUILD_BACKEND" = 'git' ]; then
@@ -2185,7 +2185,7 @@ github_download() {
         notice "Downloading (from GitHub) Erlang/OTP $1 to $KERL_DOWNLOAD_DIR..."
         http_code=$(_curl "$tarball_file" "$tarball_url")
         if [ 200 != "$http_code" ]; then
-            error "failed: _curl $tarball_url returned $http_code"
+            error "failed: _curl $tarball_url returned $http_code!"
             return 1
         fi
     else
@@ -2196,7 +2196,7 @@ github_download() {
             rm -rf "$tarball_file"
             http_code=$(_curl "$tarball_file" "$tarball_url")
             if [ 200 != "$http_code" ]; then
-                error "failed: _curl $tarball_url returned $http_code"
+                error "failed: _curl $tarball_url returned $http_code!"
                 return 1
             fi
         fi
@@ -2208,7 +2208,7 @@ tarball_download() {
         notice "Downloading tarball $1 to $KERL_DOWNLOAD_DIR..."
         http_code=$(_curl "$KERL_DOWNLOAD_DIR/$1" "$ERLANG_DOWNLOAD_URL/$1")
         if [ 200 != "$http_code" ]; then
-            error "failed: _curl $ERLANG_DOWNLOAD_URL/$1 returned $http_code"
+            error "failed: _curl $ERLANG_DOWNLOAD_URL/$1 returned $http_code!"
             return 1
         fi
         if ! update_checksum_file; then
@@ -2222,7 +2222,7 @@ tarball_download() {
     SUM="$($MD5SUM "$KERL_DOWNLOAD_DIR/$1" | cut -d' ' -f "$MD5SUM_FIELD")"
     ORIG_SUM="$(\grep -F "$1" "$KERL_DOWNLOAD_DIR"/MD5 | cut -d' ' -f2)"
     if [ "$SUM" != "$ORIG_SUM" ]; then
-        error "checksum error; check the files in $KERL_DOWNLOAD_DIR."
+        error "checksum error; check file $1 in $KERL_DOWNLOAD_DIR."
         return 1
     fi
     success "Checksum verified: $SUM."
@@ -2232,7 +2232,7 @@ upgrade_kerl() {
     install_folder=$1
     http_code=$(_curl "$install_folder/kerl" "$KERL_GIT_BASE"/kerl)
     if [ 200 != "$http_code" ]; then
-        echo "failed: _curl $KERL_GIT_BASE/kerl returned $http_code"
+        error "failed: _curl $KERL_GIT_BASE/kerl returned $http_code!"
         return 1
     fi
     chmod +x "$install_folder/kerl"

--- a/kerl
+++ b/kerl
@@ -566,6 +566,7 @@ is_valid_release() {
             return 0
         fi
     done <"$KERL_BASE_DIR"/otp_releases
+    error "'$1' is not a valid Erlang/OTP release."
     return 1
 }
 
@@ -723,7 +724,8 @@ do_git_build() {
     git_version=$2
     build_name=$3
 
-    if ! assert_build_name_unused "$build_name"; then
+    if is_build_name_used "$build_name"; then
+        error "there's already a build named '$build_name'."
         exit_build
     fi
 

--- a/kerl
+++ b/kerl
@@ -544,7 +544,7 @@ get_tarball_releases() {
         return 0
     else
         rm -f "$tmp"
-        error "_curl $ERLANG_DOWNLOAD_URL returned $http_code!"
+        error "$ERLANG_DOWNLOAD_URL returned $http_code!"
         return 1
     fi
 }
@@ -554,7 +554,7 @@ update_checksum_file() {
         notice "Getting checksum file from erlang.org..."
         http_code=$(_curl "$KERL_DOWNLOAD_DIR"/MD5 "$ERLANG_DOWNLOAD_URL"/MD5)
         if [ 200 != "$http_code" ]; then
-            error "_curl $ERLANG_DOWNLOAD_URL/MD5 returned $http_code!"
+            error "$ERLANG_DOWNLOAD_URL/MD5 returned $http_code!"
             return 1
         fi
     fi
@@ -2187,7 +2187,7 @@ github_download() {
         notice "Downloading (from GitHub) Erlang/OTP $1 to $KERL_DOWNLOAD_DIR..."
         http_code=$(_curl "$tarball_file" "$tarball_url")
         if [ 200 != "$http_code" ]; then
-            error "_curl $tarball_url returned $http_code!"
+            error "$tarball_url returned $http_code!"
             return 1
         fi
     else
@@ -2198,7 +2198,7 @@ github_download() {
             rm -rf "$tarball_file"
             http_code=$(_curl "$tarball_file" "$tarball_url")
             if [ 200 != "$http_code" ]; then
-                error "_curl $tarball_url returned $http_code!"
+                error "$tarball_url returned $http_code!"
                 return 1
             fi
         fi
@@ -2210,7 +2210,7 @@ tarball_download() {
         notice "Downloading tarball $1 to $KERL_DOWNLOAD_DIR..."
         http_code=$(_curl "$KERL_DOWNLOAD_DIR/$1" "$ERLANG_DOWNLOAD_URL/$1")
         if [ 200 != "$http_code" ]; then
-            error "_curl $ERLANG_DOWNLOAD_URL/$1 returned $http_code!"
+            error "$ERLANG_DOWNLOAD_URL/$1 returned $http_code!"
             return 1
         fi
         if ! update_checksum_file; then
@@ -2234,7 +2234,7 @@ upgrade_kerl() {
     install_folder=$1
     http_code=$(_curl "$install_folder/kerl" "$KERL_GIT_BASE"/kerl)
     if [ 200 != "$http_code" ]; then
-        error "_curl $KERL_GIT_BASE/kerl returned $http_code!"
+        error "$KERL_GIT_BASE/kerl returned $http_code!"
         return 1
     fi
     chmod +x "$install_folder/kerl"

--- a/kerl
+++ b/kerl
@@ -412,7 +412,7 @@ get_git_releases() {
     ret=$?
     notice "Getting releases from GitHub..."
     if [ "$ret" -eq 0 ]; then
-        cut <"$tmp" -f2 |
+        if ! cut <"$tmp" -f2 |
             cut -d'/' -f3- |
             sed "$SED_OPT" \
                 -e '# Delete all tags starting with ":" as to not mix' \
@@ -497,7 +497,10 @@ get_git_releases() {
                 -e 's/^([^:]+) :/\1 00 :/' |
             LC_ALL=C sort -n |
             cut -d':' -f2- |
-            tee "$1" >/dev/null
+            tee "$1" 2>/dev/null; then
+            error "file $1 does not appear to be writable"
+            return 1
+        fi
         rm -f "$tmp"
         return 0
     else
@@ -524,14 +527,17 @@ get_tarball_releases() {
     notice "Getting releases from erlang.org..."
     http_code=$(_curl "$tmp" "$ERLANG_DOWNLOAD_URL")
     if [ 200 = "$http_code" ]; then
-        sed "$SED_OPT" \
+        if ! sed "$SED_OPT" \
             -e 's/^.*<[aA] [hH][rR][eE][fF]=\"otp_src_([-0-9A-Za-z_.]+)\.tar\.gz\">.*$/\1/' \
             -e '/^R1|^[0-9]/!d' "$tmp" |
             sed -e 's/^R\(.*\)/\1:R\1/' |
             sed -e 's/^\([^\:]*\)$/\1-z:\1/' |
             sort |
             cut -d: -f2 |
-            tee "$1" >/dev/null
+            tee "$1" 2>/dev/null; then
+            error "file $1 does not appear to be writable"
+            return 1
+        fi
         rm -f "$tmp"
         return 0
     else
@@ -562,7 +568,10 @@ check_releases() {
     # $1: force?: if force, the list is always recreated
 
     if [ "$1" = force ]; then
-        rm -f "${KERL_BASE_DIR:?}"/otp_releases
+        if ! rm -f "${KERL_BASE_DIR:?}"/otp_releases 2>/dev/null; then
+            error "${KERL_BASE_DIR:?}/otp_releases cannot be removed"
+            return 1
+        fi
     fi
     if [ ! -f "$KERL_BASE_DIR"/otp_releases ] &&
         ! get_releases "$KERL_BASE_DIR"/otp_releases; then
@@ -767,7 +776,9 @@ do_git_build() {
     fi
 
     success "Erlang/OTP '$build_name' (from git) has been successfully built."
-    list_add builds git,"$build_name"
+    if ! list_add builds git,"$build_name"; then
+        exit_build "" "$build_name"
+    fi
 
     unlock_build
 }
@@ -867,7 +878,9 @@ do_normal_build() {
         exit_build
     fi
     success "Erlang/OTP $1 ($2) has been successfully built."
-    list_add builds "$1,$2"
+    if ! list_add builds "$1,$2"; then
+        exit_build
+    fi
 
     unlock_build
 }
@@ -1687,7 +1700,9 @@ do_install() {
 
     [ -n "$KERL_RELEASE_TARGET" ] && [ -f bin/cerl ] && cp bin/cerl "$absdir/bin"
 
-    list_add installations "$build_name $absdir"
+    if ! list_add installations "$build_name $absdir"; then
+        exit_install
+    fi
 
     emit_activate "$rel" "$build_name" "$absdir" >"$absdir"/activate
     emit_activate_fish "$rel" "$build_name" "$absdir" >"$absdir"/activate.fish
@@ -2080,15 +2095,24 @@ list_add() {
                 return 0
             fi
         done <"$KERL_BASE_DIR/otp_$1"
-        echo "$2" >>"$KERL_BASE_DIR/otp_$1"
+        if ! echo "$2" | tee -a "$KERL_BASE_DIR/otp_$1" 2>/dev/null; then
+            error "file $KERL_BASE_DIR/otp_$1 does not appear to be writable"
+            return 1
+        fi
     else
-        echo "$2" >"$KERL_BASE_DIR/otp_$1"
+        if ! echo "$2" | tee "$KERL_BASE_DIR/otp_$1" 2>/dev/null; then
+            error "file $KERL_BASE_DIR/otp_$1 does not appear to be writable"
+            return 1
+        fi
     fi
 }
 
 list_remove() {
     if [ -f "$KERL_BASE_DIR/otp_$1" ]; then
-        sed "$SED_OPT" -i -e "/^.*$2$/d" "$KERL_BASE_DIR/otp_$1"
+        if ! sed "$SED_OPT" -i -e "/^.*$2$/d" "$KERL_BASE_DIR/otp_$1" 2>/dev/null; then
+            error "file $KERL_BASE_DIR/otp_$1 does not appear writable"
+            return 1
+        fi
     fi
 }
 
@@ -2452,7 +2476,9 @@ delete)
                 exit 1
             fi
         fi
-        list_remove "$2"s "$rel,$3"
+        if ! list_remove "$2"s "$rel,$3"; then
+            exit 1
+        fi
         notice "Build '$3' has been deleted."
         ;;
     installation)
@@ -2473,7 +2499,9 @@ delete)
             fi
         fi
         escaped="$(echo "$3" | \sed "$SED_OPT" -e 's#/$##' -e 's#\/#\\\/#g')"
-        list_remove "$2"s "$escaped"
+        if ! list_remove "$2"s "$escaped"; then
+            exit 1
+        fi
         notice "Installation '$3' has been deleted."
         ;;
     *)

--- a/kerl
+++ b/kerl
@@ -410,6 +410,7 @@ get_git_releases() {
     tmp="$(mktemp "$TMP_DIR"/kerl.XXXXXX)"
     git ls-remote --tags --refs "$OTP_GITHUB_URL" >"$tmp"
     ret=$?
+    notice "Getting releases from GitHub..."
     if [ "$ret" -eq 0 ]; then
         cut <"$tmp" -f2 |
             cut -d'/' -f3- |
@@ -501,7 +502,7 @@ get_git_releases() {
         return 0
     else
         rm -f "$tmp"
-        error "failed to get releases from GitHub; git ls-remote --tags --refs $OTP_GITHUB_URL returned $ret!"
+        error "failed: git ls-remote --tags --refs $OTP_GITHUB_URL returned $ret!"
         return 1
     fi
 }
@@ -510,6 +511,7 @@ get_tarball_releases() {
     tmp="$(mktemp "$TMP_DIR"/kerl.XXXXXX)"
     curl_ret=$(\curl -qsL --output "$tmp" --write-out '%{http_code}' "$ERLANG_DOWNLOAD_URL")
     if [ 200 = "$curl_ret" ]; then
+    notice "Getting releases from erlang.org..."
         sed "$SED_OPT" \
             -e 's/^.*<[aA] [hH][rR][eE][fF]=\"otp_src_([-0-9A-Za-z_.]+)\.tar\.gz\">.*$/\1/' \
             -e '/^R1|^[0-9]/!d' "$tmp" |

--- a/kerl
+++ b/kerl
@@ -196,7 +196,7 @@ autoclean() {
         tmplf="$(mktemp "$TMP_DIR"/kerl.XXXXXX)"
         test -f "$BUILD_LOGFILE" && cp -f "$BUILD_LOGFILE" "$tmplf"
         # Cleaning current build
-        cd - 1>/dev/null 2>&1 || return 1
+        cd - 1>/dev/null 2>&1 || return 0
         test -n "$1" && ${_KERL_SCRIPT} cleanup "$1"
         # Copy BUILD_LOGFILE back to keep track of all attempts until success
         mkdir -p "$(dirname "$BUILD_LOGFILE")"
@@ -1664,9 +1664,7 @@ do_install() {
 
     [ -n "$KERL_RELEASE_TARGET" ] && [ -f bin/cerl ] && cp bin/cerl "$absdir/bin"
 
-    if ! list_add installations "$build_name $absdir"; then
-        exit_install
-    fi
+    list_add installations "$build_name $absdir"
 
     emit_activate "$rel" "$build_name" "$absdir" >"$absdir"/activate
     emit_activate_fish "$rel" "$build_name" "$absdir" >"$absdir"/activate.fish
@@ -1789,7 +1787,7 @@ do_plt() {
         fi
     else
         error "no Erlang/OTP installation is currently active"
-        return 2
+        return 1
     fi
 }
 
@@ -1798,10 +1796,8 @@ print_buildopts() {
     if [ -f "$buildopts" ]; then
         notice "The build options for the active installation are:"
         cat "$buildopts"
-        return 0
     else
         error "the build options for the active installation are not available."
-        return 1
     fi
 }
 
@@ -2052,9 +2048,9 @@ list_add() {
                 return 0
             fi
         done <"$KERL_BASE_DIR/otp_$1"
-        echo "$2" >>"$KERL_BASE_DIR/otp_$1" || return 1
+        echo "$2" >>"$KERL_BASE_DIR/otp_$1"
     else
-        echo "$2" >"$KERL_BASE_DIR/otp_$1" || return 1
+        echo "$2" >"$KERL_BASE_DIR/otp_$1"
     fi
 }
 
@@ -2374,14 +2370,15 @@ path)
                     match="$ins"
                 else
                     error "too many matching installations."
-                    exit 2
+                    exit 1
                 fi
             fi
         done
         if [ -n "$match" ]; then
             echo "$match"
         else
-            error "no matching installation found." && exit 1
+            error "no matching installation found."
+            exit 1
         fi
     fi
     ;;

--- a/kerl
+++ b/kerl
@@ -393,12 +393,14 @@ k_usage() {
 if [ $# -eq 0 ]; then k_usage; fi
 
 get_releases() {
+    # $1: path to file otp_releases
+
     if [ "$KERL_BUILD_BACKEND" = 'git' ]; then
-        if ! get_git_releases; then
+        if ! get_git_releases "$1"; then
             return 1
         fi
     else
-        if ! get_tarball_releases; then
+        if ! get_tarball_releases "$1"; then
             return 1
         fi
     fi
@@ -493,26 +495,34 @@ get_git_releases() {
                 -e '#  -    "19 00 00 02 :OTP-19.0-rc.2"   =>  "19 00 00 02 00 :OTP-19.0-rc.2"' \
                 -e 's/^([^:]+) :/\1 00 :/' |
             LC_ALL=C sort -n |
-            cut -d':' -f2-
+            cut -d':' -f2- |
+            tee "$1" >/dev/null
+        rm -f "$tmp"
+        return 0
+    else
+        rm -f "$tmp"
+        error "failed to get releases from GitHub; git ls-remote --tags --refs $OTP_GITHUB_URL returned $ret!"
+        return 1
     fi
-    rm -f "$tmp"
-    # shellcheck disable=SC2248  # Prefer double quoting even when variables don't contain special characters.
-    return $ret
 }
 
 get_tarball_releases() {
     tmp="$(mktemp "$TMP_DIR"/kerl.XXXXXX)"
-    if [ 200 = "$(\curl -qsL --output "$tmp" --write-out '%{http_code}' "$ERLANG_DOWNLOAD_URL"/)" ]; then
+    curl_ret=$(\curl -qsL --output "$tmp" --write-out '%{http_code}' "$ERLANG_DOWNLOAD_URL")
+    if [ 200 = "$curl_ret" ]; then
         sed "$SED_OPT" \
             -e 's/^.*<[aA] [hH][rR][eE][fF]=\"otp_src_([-0-9A-Za-z_.]+)\.tar\.gz\">.*$/\1/' \
             -e '/^R1|^[0-9]/!d' "$tmp" |
             sed -e 's/^R\(.*\)/\1:R\1/' |
             sed -e 's/^\([^\:]*\)$/\1-z:\1/' |
-            sort | cut -d: -f2
-        rm "$tmp"
+            sort |
+            cut -d: -f2 |
+            tee "$1" >/dev/null
+        rm -f "$tmp"
         return 0
     else
-        rm "$tmp"
+        rm -f "$tmp"
+        error "failed to get releases from erlang.org; curl -qsL --output $tmp --write-out '%{http_code}' $ERLANG_DOWNLOAD_URL returned $curl_ret!"
         return 1
     fi
 }
@@ -531,8 +541,13 @@ ensure_checksum_file() {
 }
 
 check_releases() {
+    # $1: force? (if true, the list is always recreated)
+
+    if [ "$1" = true ]; then
+        rm -f "${KERL_BASE_DIR:?}"/otp_releases
+    fi
     if [ ! -f "$KERL_BASE_DIR"/otp_releases ] &&
-        ! get_releases >"$KERL_BASE_DIR"/otp_releases; then
+        ! get_releases "$KERL_BASE_DIR"/otp_releases; then
         return 1
     fi
 }
@@ -2261,13 +2276,11 @@ update)
         usage_exit "update releases"
     fi
 
-    rm -f "${KERL_BASE_DIR:?}"/otp_releases
-    if check_releases; then
+    if ! check_releases true; then
+        exit 1
+    else
         notice "The available releases are:"
         list_print releases
-    else
-        error "check releases failed!"
-        exit 1
     fi
     ;;
 upgrade)

--- a/kerl
+++ b/kerl
@@ -1830,11 +1830,11 @@ do_plt() {
             success "$plt"
             return 0
         else
-            error "there is no Dialyzer PLT for the active installation."
+            warn "there is no Dialyzer PLT for the active installation."
             return 1
         fi
     else
-        error "no Erlang/OTP installation is currently active."
+        warn "no Erlang/OTP installation is currently active."
         return 1
     fi
 }
@@ -2415,7 +2415,7 @@ list)
         ;;
     *)
         if [ -n "$2" ]; then
-            error "cannot list $2."
+            error "cannot list (unknown) $2."
         fi
         usage_exit "list <releases|builds|installations> [all]"
         ;;
@@ -2434,7 +2434,7 @@ path)
     if [ -z "$2" ]; then
         activepath=$(get_active_path)
         if [ -z "$activepath" ]; then
-            error "no active kerl-managed Erlang/OTP installation."
+            warn "no active kerl-managed Erlang/OTP installation."
             exit 1
         fi
         tip "$activepath"

--- a/kerl
+++ b/kerl
@@ -507,11 +507,23 @@ get_git_releases() {
     fi
 }
 
+_curl() {
+    # $1: <file> to write output to, instead of stdout (if body_only function only returns body)
+    # $2: URL to consider
+    # $3: extra options
+
+    if [ "$1" != body_only ]; then
+        _curl_extra="--output $1 --write-out %{http_code}"
+    fi
+    # shellcheck disable=SC2086  # Double quote to prevent globbing and word splitting
+    \curl -q --silent --location --fail $2 $3 $_curl_extra
+}
+
 get_tarball_releases() {
     tmp="$(mktemp "$TMP_DIR"/kerl.XXXXXX)"
-    curl_ret=$(\curl -qsL --output "$tmp" --write-out '%{http_code}' "$ERLANG_DOWNLOAD_URL")
-    if [ 200 = "$curl_ret" ]; then
     notice "Getting releases from erlang.org..."
+    http_code=$(_curl "$tmp" "$ERLANG_DOWNLOAD_URL")
+    if [ 200 = "$http_code" ]; then
         sed "$SED_OPT" \
             -e 's/^.*<[aA] [hH][rR][eE][fF]=\"otp_src_([-0-9A-Za-z_.]+)\.tar\.gz\">.*$/\1/' \
             -e '/^R1|^[0-9]/!d' "$tmp" |
@@ -524,7 +536,7 @@ get_tarball_releases() {
         return 0
     else
         rm -f "$tmp"
-        error "failed to get releases from erlang.org; curl -qsL --output $tmp --write-out '%{http_code}' $ERLANG_DOWNLOAD_URL returned $curl_ret!"
+        error "failed: _curl $ERLANG_DOWNLOAD_URL returned $http_code!"
         return 1
     fi
 }
@@ -532,10 +544,9 @@ get_tarball_releases() {
 update_checksum_file() {
     if [ "$KERL_BUILD_BACKEND" != 'git' ]; then
         notice "Getting checksum file from erlang.org..."
-        curl -s -f -L -o "$KERL_DOWNLOAD_DIR"/MD5 "$ERLANG_DOWNLOAD_URL"/MD5
-        ret=$?
-        if [ "$ret" -ne 0 ]; then
-            error "failed: curl -s -f -L -o $KERL_DOWNLOAD_DIR/MD5 $ERLANG_DOWNLOAD_URL/MD5 returned $ret"
+        http_code=$(_curl "$KERL_DOWNLOAD_DIR"/MD5 "$ERLANG_DOWNLOAD_URL"/MD5)
+        if [ 200 != "$http_code" ]; then
+            error "failed: _curl $ERLANG_DOWNLOAD_URL/MD5 returned $http_code"
             return 1
         fi
     fi
@@ -2138,17 +2149,17 @@ github_download() {
     tarball_file="$KERL_DOWNLOAD_DIR/$2"
     tarball_url="$OTP_GITHUB_URL/archive/$2"
     prebuilt_url="$OTP_GITHUB_URL/releases/download/OTP-$1/otp_src_$1.tar.gz"
-    if curl --silent --location --fail -I "$prebuilt_url" >/dev/null; then
+    http_code=$(_curl /dev/null "$prebuilt_url" "-I")
+    if [ 200 = "$http_code" ]; then
         tarball_url=$prebuilt_url
         unset KERL_USE_AUTOCONF
     fi
     # if the file doesn't exist or the file has no size
     if [ ! -s "$tarball_file" ]; then
         notice "Downloading (from GitHub) Erlang/OTP $1 to $KERL_DOWNLOAD_DIR..."
-        curl -s -f -L -o "$tarball_file" "$tarball_url"
-        ret=$?
-        if [ "$ret" -ne 0 ]; then
-            error "failed: curl -s -f -L -o $tarball_file $tarball_url returned $ret"
+        http_code=$(_curl "$tarball_file" "$tarball_url")
+        if [ 200 != "$http_code" ]; then
+            error "failed: _curl $tarball_url returned $http_code"
             return 1
         fi
     else
@@ -2157,10 +2168,9 @@ github_download() {
         if ! gunzip -t "$tarball_file" 2>/dev/null; then
             notice "$tarball_file (from GitHub) corrupted; re-downloading..."
             rm -rf "$tarball_file"
-            curl -s -f -L -o "$tarball_file" "$tarball_url"
-            ret=$?
-            if [ "$ret" -ne 0 ]; then
-                error "failed: curl -s -f -L -o $tarball_file $tarball_url returned $ret"
+            http_code=$(_curl "$tarball_file" "$tarball_url")
+            if [ 200 != "$http_code" ]; then
+                error "failed: _curl $tarball_url returned $http_code"
                 return 1
             fi
         fi
@@ -2170,10 +2180,9 @@ github_download() {
 tarball_download() {
     if [ ! -s "$KERL_DOWNLOAD_DIR/$1" ]; then
         notice "Downloading tarball $1 to $KERL_DOWNLOAD_DIR..."
-        curl -s -f -L -o "$KERL_DOWNLOAD_DIR/$1" "$ERLANG_DOWNLOAD_URL/$1"
-        ret=$?
-        if [ "$ret" -ne 0 ]; then
-            error "failed: curl -s -f -L -o $KERL_DOWNLOAD_DIR/$1 $ERLANG_DOWNLOAD_URL/$1 returned $ret"
+        http_code=$(_curl "$KERL_DOWNLOAD_DIR/$1" "$ERLANG_DOWNLOAD_URL/$1")
+        if [ 200 != "$http_code" ]; then
+            error "failed: _curl $ERLANG_DOWNLOAD_URL/$1 returned $http_code"
             return 1
         fi
         if ! update_checksum_file; then
@@ -2195,7 +2204,11 @@ tarball_download() {
 
 upgrade_kerl() {
     install_folder=$1
-    curl -s -o "$install_folder/kerl" "$KERL_GIT_BASE"/kerl
+    http_code=$(_curl "$install_folder/kerl" "$KERL_GIT_BASE"/kerl)
+    if [ 200 != "$http_code" ]; then
+        echo "failed: _curl $KERL_GIT_BASE/kerl returned $http_code"
+        return 1
+    fi
     chmod +x "$install_folder/kerl"
     version=$(kerl version)
     current_kerl_path="$(command -v kerl)"
@@ -2325,12 +2338,14 @@ upgrade)
     else
         version=$(kerl version)
         notice "Local kerl found ($current_kerl_path) at version $version."
-        latest=$(curl -s "$KERL_GIT_BASE"/LATEST)
+        latest=$(_curl body_only "$KERL_GIT_BASE"/LATEST)
         notice "Remote kerl found at version $latest."
         if [ "$version" != "$latest" ]; then
             notice "Versions are different. Upgrading to $latest..."
             current_kerl_path=$(dirname "$current_kerl_path")
-            upgrade_kerl "$current_kerl_path"
+            if ! upgrade_kerl "$current_kerl_path"; then
+                exit 1
+            fi
         else
             success "No upgrade required."
         fi

--- a/kerl
+++ b/kerl
@@ -497,7 +497,7 @@ get_git_releases() {
                 -e 's/^([^:]+) :/\1 00 :/' |
             LC_ALL=C sort -n |
             cut -d':' -f2- |
-            tee "$1" 2>/dev/null; then
+            tee "$1" >/dev/null 2>&1; then
             error "file $1 does not appear to be writable"
             return 1
         fi
@@ -534,7 +534,7 @@ get_tarball_releases() {
             sed -e 's/^\([^\:]*\)$/\1-z:\1/' |
             sort |
             cut -d: -f2 |
-            tee "$1" 2>/dev/null; then
+            tee "$1" >/dev/null 2>&1; then
             error "file $1 does not appear to be writable"
             return 1
         fi
@@ -2097,12 +2097,12 @@ list_add() {
                 return 0
             fi
         done <"$KERL_BASE_DIR/otp_$1"
-        if ! echo "$2" | tee -a "$KERL_BASE_DIR/otp_$1" 2>/dev/null; then
+        if ! echo "$2" | tee -a "$KERL_BASE_DIR/otp_$1" >/dev/null 2>&1; then
             error "file $KERL_BASE_DIR/otp_$1 does not appear to be writable"
             return 1
         fi
     else
-        if ! echo "$2" | tee "$KERL_BASE_DIR/otp_$1" 2>/dev/null; then
+        if ! echo "$2" | tee "$KERL_BASE_DIR/otp_$1" >/dev/null 2>&1; then
             error "file $KERL_BASE_DIR/otp_$1 does not appear to be writable"
             return 1
         fi

--- a/kerl
+++ b/kerl
@@ -530,7 +530,12 @@ get_tarball_releases() {
 update_checksum_file() {
     if [ "$KERL_BUILD_BACKEND" != 'git' ]; then
         notice "Getting checksum file from erlang.org..."
-        curl -s -f -L -o "$KERL_DOWNLOAD_DIR"/MD5 "$ERLANG_DOWNLOAD_URL"/MD5 || return 1
+        curl -s -f -L -o "$KERL_DOWNLOAD_DIR"/MD5 "$ERLANG_DOWNLOAD_URL"/MD5
+        ret=$?
+        if [ "$ret" -ne 0 ]; then
+            error "failed: curl -s -f -L -o $KERL_DOWNLOAD_DIR/MD5 $ERLANG_DOWNLOAD_URL/MD5 returned $ret"
+            return 1
+        fi
     fi
 }
 
@@ -1055,7 +1060,10 @@ _do_build() {
     esac
 
     ERL_TOP="$KERL_BUILD_DIR/$2/otp_src_$1"
-    cd "$ERL_TOP" || return 1
+    if ! cd "$ERL_TOP"; then
+        error "couldn't cd into $ERL_TOP"
+        return 1
+    fi
 
     # Set configuration flags given applications white/black lists
     if [ -n "$KERL_CONFIGURE_APPLICATIONS" ]; then
@@ -1196,7 +1204,10 @@ _do_build() {
             case $r_type in
             opt | debug)
                 notice "Also building for Erlang/OTP $1 ($2) $r_type VM; please wait..."
-                cd "$ERL_TOP" || return 1
+                if ! cd "$ERL_TOP"; then
+                    error "couldn't cd into $ERL_TOP"
+                    return 1
+                fi
                 if ! log_build_cmd "make TYPE=$r_type ERL_TOP=$ERL_TOP"; then
                     show_build_logfile "build of '$r_type' VM failed."
                     list_remove builds "$1 $2"
@@ -1205,7 +1216,10 @@ _do_build() {
                 ;;
             gcov | gprof | valgrind | asan | lcnt)
                 notice "Also building for Erlang/OTP $1 ($2) $r_type VM; please wait..."
-                cd "$ERL_TOP/erts/emulator" || return 1
+                if ! cd "$ERL_TOP/erts/emulator"; then
+                    error "couldn't cd into $ERL_TOP/erts/emulator"
+                    return 1
+                fi
                 if ! log_build_cmd "make $r_type ERL_TOP=$ERL_TOP"; then
                     show_build_logfile "build of '$r_type' VM failed."
                     list_remove builds "$1 $2"
@@ -1686,7 +1700,10 @@ do_install() {
     emit_activate_csh "$rel" "$build_name" "$absdir" >"$absdir"/activate.csh
 
     if [ -n "$KERL_BUILD_DOCS" ]; then
-        cd "$ERL_TOP" || return 1
+        if ! cd "$ERL_TOP"; then
+            error "couldn't cd into $ERL_TOP"
+            exit_install
+        fi
         if ! log_install_cmd "ERL_TOP=$ERL_TOP make release_docs DOC_TARGETS=$KERL_DOC_TARGETS RELEASE_ROOT=$absdir"; then
             show_install_logfile "couldn't install docs for Erlang/OTP $rel ($build_name) in $absdir"
             exit_install
@@ -1771,7 +1788,10 @@ download_htmldocs() {
 
 build_plt() {
     dialyzerd="$1"/dialyzer
-    mkdir -p "$dialyzerd" || return 1
+    if ! mkdir -p "$dialyzerd"; then
+        error "couldn't create folder $dialyzerd"
+        return 1
+    fi
     plt="$dialyzerd"/plt
     build_log="$dialyzerd"/build.log
     dirs=$(\find "$1"/lib -maxdepth 2 -name ebin -type d -exec dirname {} \;)
@@ -2111,7 +2131,10 @@ make_filename() {
 }
 
 download() {
-    mkdir -p "$KERL_DOWNLOAD_DIR" || return 1
+    if ! mkdir -p "$KERL_DOWNLOAD_DIR"; then
+        error "couldn't create folder $KERL_DOWNLOAD_DIR"
+        return 1
+    fi
     if [ "$KERL_BUILD_BACKEND" = 'git' ]; then
         FILENAME=$(make_filename "$1")
         if ! github_download "$1" "$FILENAME".tar.gz; then
@@ -2136,14 +2159,24 @@ github_download() {
     # if the file doesn't exist or the file has no size
     if [ ! -s "$tarball_file" ]; then
         notice "Downloading (from GitHub) Erlang/OTP $1 to $KERL_DOWNLOAD_DIR..."
-        curl -s -f -L -o "$tarball_file" "$tarball_url" || return 1
+        curl -s -f -L -o "$tarball_file" "$tarball_url"
+        ret=$?
+        if [ "$ret" -ne 0 ]; then
+            error "failed: curl -s -f -L -o $tarball_file $tarball_url returned $ret"
+            return 1
+        fi
     else
         # If the downloaded tarball was corrupted due to interruption while
         # downloading.
         if ! gunzip -t "$tarball_file" 2>/dev/null; then
             notice "$tarball_file (from GitHub) corrupted; re-downloading..."
             rm -rf "$tarball_file"
-            curl -s -f -L -o "$tarball_file" "$tarball_url" || return 1
+            curl -s -f -L -o "$tarball_file" "$tarball_url"
+            ret=$?
+            if [ "$ret" -ne 0 ]; then
+                error "failed: curl -s -f -L -o $tarball_file $tarball_url returned $ret"
+                return 1
+            fi
         fi
     fi
 }
@@ -2151,7 +2184,12 @@ github_download() {
 tarball_download() {
     if [ ! -s "$KERL_DOWNLOAD_DIR/$1" ]; then
         notice "Downloading tarball $1 to $KERL_DOWNLOAD_DIR..."
-        curl -s -f -L -o "$KERL_DOWNLOAD_DIR/$1" "$ERLANG_DOWNLOAD_URL/$1" || return 1
+        curl -s -f -L -o "$KERL_DOWNLOAD_DIR/$1" "$ERLANG_DOWNLOAD_URL/$1"
+        ret=$?
+        if [ "$ret" -ne 0 ]; then
+            error "failed: curl -s -f -L -o $KERL_DOWNLOAD_DIR/$1 $ERLANG_DOWNLOAD_URL/$1 returned $ret"
+            return 1
+        fi
         if ! update_checksum_file; then
             return 1
         fi

--- a/kerl
+++ b/kerl
@@ -152,7 +152,9 @@ log_install_cmd() {
 # Check if tput is available for colorize
 tp=$(tput sgr0 1>/dev/null 2>&1 && printf "OK" || printf "")
 if [ -z "$tp" ]; then
-    nocolor "Colorization disabled as 'tput' (via 'ncurses') seems to be unavailable."
+    if [ -z "$CI" ]; then
+        nocolor "Colorization disabled as 'tput' (via 'ncurses') seems to be unavailable."
+    fi
     KERL_COLOR_AVAILABLE=0
     KERL_COLORIZE=0 # Force disabling colorization
 else

--- a/kerl
+++ b/kerl
@@ -1996,7 +1996,7 @@ maybe_remove() {
     ACTIVE_PATH="$(get_active_path)"
     if [ "$candidate" = "$ACTIVE_PATH" ]; then
         error "you cannot delete the active installation. Deactivate it first."
-        exit 1
+        return 1
     fi
 
     rm -Rf "$1"
@@ -2426,7 +2426,9 @@ delete)
 
         rel="$(get_release_from_name "$3")"
         if [ -d "${KERL_BUILD_DIR:?}/$3" ]; then
-            maybe_remove "${KERL_BUILD_DIR:?}/$3"
+            if ! maybe_remove "${KERL_BUILD_DIR:?}/$3"; then
+                exit 1
+            fi
         else
             if [ -z "$rel" ]; then
                 error "no build named '$3'!"
@@ -2445,9 +2447,13 @@ delete)
             exit 1
         fi
         if [ -d "$3" ]; then
-            maybe_remove "$3"
+            if ! maybe_remove "$3"; then
+                exit 1
+            fi
         else
-            maybe_remove "$(get_install_path_from_name "$3")"
+            if ! maybe_remove "$(get_install_path_from_name "$3")"; then
+                exit 1
+            fi
         fi
         escaped="$(echo "$3" | \sed "$SED_OPT" -e 's#/$##' -e 's#\/#\\\/#g')"
         list_remove "$2"s "$escaped"

--- a/kerl
+++ b/kerl
@@ -2497,16 +2497,13 @@ status)
     notice "Available installations:"
     list_print installations
     nocolor '----------'
-    if do_active; then
-        ACTIVE_PATH=$(get_active_path)
-        if [ -n "$ACTIVE_PATH" ]; then
-            do_plt "$ACTIVE_PATH"
-            print_buildopts "$ACTIVE_PATH"
-        else
-            error "no Erlang/OTP installation is currently active."
-            exit 1
-        fi
+    if ! do_active; then
+        exit 1
     fi
+
+    ACTIVE_PATH=$(get_active_path)
+    do_plt "$ACTIVE_PATH"
+    print_buildopts "$ACTIVE_PATH"
     ;;
 prompt)
     if [ $# -ne 1 ]; then


### PR DESCRIPTION
# Description

I was going for #202, but while testing the initial conditions to replicate it I found myself having calls to functions that would silently fail. I decided to look into that as it helps in development and consumption.

As an example, `kerl build` > `do_normal_build` > `download` > `tarball_download` would fail if the build was not found in `erlang.org`, but silently.

```zsh
➜  kerl git:(master) KERL_BUILD_BACKEND=tarball ./kerl build 26.0.2
Downloading tarball otp_src_26.0.2.tar.gz to .../.kerl/archives...
➜  kerl
```

Now we get

```zsh
➜  kerl git:(fix/improve-output-on-error) ✗ KERL_BUILD_BACKEND=tarball ./kerl build 26.0.2
Downloading tarball otp_src_26.0.2.tar.gz to .../.kerl/archives...
ERROR: _curl https://erlang.org/downloa/otp_src_26.0.2.tar.gz returned 404!
```

I ended up reviewing basically all `exit` and `return` sites to increase consistency and improve logging.

~Opening this as draft while I perform some more tests and local analysis.~

## Further considerations

I tried to do as much commit-by-commit in this one as possible, then I reviewed the individual commits to add comments on changes that were later reversed on self-review.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/kerl/kerl/blob/main/CONTRIBUTING.md)
