### PR TITLE
Fix awk script

### DIFF
--- a/kerl
+++ b/kerl
@@ -744,7 +744,7 @@ show_configuration_warnings() {
         tail -n +$((INDEX + 3)) "$1" |
             sed -n '1,/\*/p' |
             awk -F: -v logfile="$1" -v section="$2" \
-                'BEGIN { printf "%s (See: %s)\n", section, log file }
+                'BEGIN { printf "%s (See: %s)\n", section, logfile }
                  /^[^\*]/ { print " *", $0 }
                  END { print "" } '
     fi


### PR DESCRIPTION
# Description

I was a bit to eager pressing Ctrl-V on that occurrence of "logfile" when I wanted to replace English "logfile" to "log file" but on comments/logs alone...

Closes #476.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/kerl/kerl/blob/main/CONTRIBUTING.md)
