### PR TITLE
Fix typos in security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -9,7 +9,7 @@ Find below updated information on our security policy.
 We take the security of this software seriously.
 
 We don't implement a bug bounty program or bounty rewards, but will work with
-you closed to ensure that your findings gets the appropriate handling.
+you to ensure that your findings get the appropriate handling.
 
 ## Reporting Security Issues
 


### PR DESCRIPTION
# Description

Two minor typos.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/kerl/kerl/blob/main/CONTRIBUTING.md)
