### PR TITLE
Fix verification for `$#` in `kerl delete build`

### DIFF
--- a/kerl
+++ b/kerl
@@ -2438,7 +2438,7 @@ path)
 delete)
     case "$2" in
     build)
-        if [ $# -lt 2 ] || [ $# -gt 3 ]; then
+        if [ $# -ne 3 ]; then
             usage_exit "delete build [build_name]"
         fi
 


### PR DESCRIPTION
# Description

We want the number of arguments to be exactly 3.

It's not a big issue, but something like `ERROR: no build named ''!` doesn't seem to make a lot of sense UX-wise.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/kerl/kerl/blob/main/CONTRIBUTING.md)
