### PR TITLE
Attempt auto-cleanup of `otp_builds` and `otp_installations`, at every run

### DIFF
--- a/kerl
+++ b/kerl
@@ -2110,15 +2110,15 @@ get_active_path() {
 
 fix_otp_installations() {
     if [ -f "$KERL_BASE_DIR"/otp_installations ]; then
-        nonexisting_names=""
+        missing_names=""
         while read -r l; do
             path=$(echo "$l" | cut -d' ' -f2)
             if [ ! -e "$path" ]; then
-                nonexisting_names="$path $nonexisting_names"
+                missing_names="$path $missing_names"
             fi
         done <"$KERL_BASE_DIR"/otp_installations
-        for nonexisting_name in ${nonexisting_names}; do
-            escaped="$(echo "$nonexisting_name" | \sed "$SED_OPT" -e 's#/$##' -e 's#\/#\\\/#g')"
+        for missing_name in ${missing_names}; do
+            escaped="$(echo "$missing_name" | \sed "$SED_OPT" -e 's#/$##' -e 's#\/#\\\/#g')"
             list_remove installations "$escaped"
         done
     fi
@@ -2126,16 +2126,16 @@ fix_otp_installations() {
 
 fix_otp_builds() {
     if [ -f "$KERL_BASE_DIR"/otp_builds ]; then
-        nonexisting_rels=""
+        missing_rels=""
         while read -r l; do
             rel=$(echo "$l" | cut -d, -f1)
             name=$(echo "$l" | cut -d, -f2)
             if [ ! -e "${KERL_BUILD_DIR}/${name}" ]; then
-                nonexisting_rels="${rel},${name} $nonexisting_rels"
+                missing_rels="${rel},${name} $missing_rels"
             fi
         done <"$KERL_BASE_DIR"/otp_builds
-        for nonexisting_rel in ${nonexisting_rels}; do
-            list_remove "${nonexisting_rel}"
+        for missing_rel in ${missing_rels}; do
+            list_remove "${missing_rel}"
         done
     fi
 }

--- a/kerl
+++ b/kerl
@@ -2135,7 +2135,7 @@ fix_otp_builds() {
             fi
         done <"$KERL_BASE_DIR"/otp_builds
         for missing_rel in ${missing_rels}; do
-            list_remove "${missing_rel}"
+            list_remove builds "${missing_rel}"
         done
     fi
 }

--- a/kerl
+++ b/kerl
@@ -2108,6 +2108,39 @@ get_active_path() {
     fi
 }
 
+fix_otp_installations() {
+    if [ -f "$KERL_BASE_DIR"/otp_installations ]; then
+        inexisting_names=""
+        while read -r l; do
+            names=$(echo "$l" | cut -d' ' -f1)
+            path=$(echo "$l" | cut -d' ' -f2)
+            if [ ! -e "$path" ]; then
+                inexisting_names="$path $inexisting_names"
+            fi
+        done <"$KERL_BASE_DIR"/otp_installations
+        for inexisting_name in ${inexisting_names}; do
+            escaped="$(echo "$inexisting_name" | \sed "$SED_OPT" -e 's#/$##' -e 's#\/#\\\/#g')"
+            list_remove installations "$escaped"
+        done
+    fi
+}
+
+fix_otp_builds() {
+    if [ -f "$KERL_BASE_DIR"/otp_builds ]; then
+        inexisting_rels=""
+        while read -r l; do
+            rel=$(echo "$l" | cut -d, -f1)
+            name=$(echo "$l" | cut -d, -f2)
+            if [ ! -e "${KERL_BUILD_DIR}/${name}" ]; then
+                inexisting_rels="${rel},${name} $inexisting_rels"
+            fi
+        done <"$KERL_BASE_DIR"/otp_builds
+        for inexisting_rel in ${inexisting_rels}; do
+            list_remove "${inexisting_rel}"
+        done
+    fi
+}
+
 get_name_from_install_path() {
     if [ -f "$KERL_BASE_DIR"/otp_installations ]; then
         \grep -m1 -E "$1$" "$KERL_BASE_DIR"/otp_installations | cut -d' ' -f1
@@ -2221,6 +2254,9 @@ upgrade_kerl() {
     current_kerl_path="$(command -v kerl)"
     notice "kerl $version is now available at $current_kerl_path."
 }
+
+fix_otp_builds
+fix_otp_installations
 
 case "$1" in
 version)

--- a/kerl
+++ b/kerl
@@ -2110,15 +2110,15 @@ get_active_path() {
 
 fix_otp_installations() {
     if [ -f "$KERL_BASE_DIR"/otp_installations ]; then
-        inexisting_names=""
+        nonexisting_names=""
         while read -r l; do
             path=$(echo "$l" | cut -d' ' -f2)
             if [ ! -e "$path" ]; then
-                inexisting_names="$path $inexisting_names"
+                nonexisting_names="$path $nonexisting_names"
             fi
         done <"$KERL_BASE_DIR"/otp_installations
-        for inexisting_name in ${inexisting_names}; do
-            escaped="$(echo "$inexisting_name" | \sed "$SED_OPT" -e 's#/$##' -e 's#\/#\\\/#g')"
+        for nonexisting_name in ${nonexisting_names}; do
+            escaped="$(echo "$nonexisting_name" | \sed "$SED_OPT" -e 's#/$##' -e 's#\/#\\\/#g')"
             list_remove installations "$escaped"
         done
     fi
@@ -2126,16 +2126,16 @@ fix_otp_installations() {
 
 fix_otp_builds() {
     if [ -f "$KERL_BASE_DIR"/otp_builds ]; then
-        inexisting_rels=""
+        nonexisting_rels=""
         while read -r l; do
             rel=$(echo "$l" | cut -d, -f1)
             name=$(echo "$l" | cut -d, -f2)
             if [ ! -e "${KERL_BUILD_DIR}/${name}" ]; then
-                inexisting_rels="${rel},${name} $inexisting_rels"
+                nonexisting_rels="${rel},${name} $nonexisting_rels"
             fi
         done <"$KERL_BASE_DIR"/otp_builds
-        for inexisting_rel in ${inexisting_rels}; do
-            list_remove "${inexisting_rel}"
+        for nonexisting_rel in ${nonexisting_rels}; do
+            list_remove "${nonexisting_rel}"
         done
     fi
 }

--- a/kerl
+++ b/kerl
@@ -2110,15 +2110,15 @@ get_active_path() {
 
 fix_otp_installations() {
     if [ -f "$KERL_BASE_DIR"/otp_installations ]; then
-        missing_names=""
+        missing_paths=""
         while read -r l; do
             path=$(echo "$l" | cut -d' ' -f2)
             if [ ! -e "$path" ]; then
-                missing_names="$path $missing_names"
+                missing_paths="$path $missing_paths"
             fi
         done <"$KERL_BASE_DIR"/otp_installations
-        for missing_name in ${missing_names}; do
-            escaped="$(echo "$missing_name" | \sed "$SED_OPT" -e 's#/$##' -e 's#\/#\\\/#g')"
+        for missing_path in ${missing_paths}; do
+            escaped="$(echo "$missing_path" | \sed "$SED_OPT" -e 's#/$##' -e 's#\/#\\\/#g')"
             list_remove installations "$escaped"
         done
     fi

--- a/kerl
+++ b/kerl
@@ -2126,16 +2126,16 @@ fix_otp_installations() {
 
 fix_otp_builds() {
     if [ -f "$KERL_BASE_DIR"/otp_builds ]; then
-        missing_rels=""
+        missing_keys=""
         while read -r l; do
             rel=$(echo "$l" | cut -d, -f1)
             name=$(echo "$l" | cut -d, -f2)
             if [ ! -e "${KERL_BUILD_DIR}/${name}" ]; then
-                missing_rels="${rel},${name} $missing_rels"
+                missing_keys="${rel},${name} $missing_keys"
             fi
         done <"$KERL_BASE_DIR"/otp_builds
-        for missing_rel in ${missing_rels}; do
-            list_remove builds "${missing_rel}"
+        for missing_key in ${missing_keys}; do
+            list_remove builds "${missing_key}"
         done
     fi
 }

--- a/kerl
+++ b/kerl
@@ -2112,7 +2112,6 @@ fix_otp_installations() {
     if [ -f "$KERL_BASE_DIR"/otp_installations ]; then
         inexisting_names=""
         while read -r l; do
-            names=$(echo "$l" | cut -d' ' -f1)
             path=$(echo "$l" | cut -d' ' -f2)
             if [ ! -e "$path" ]; then
                 inexisting_names="$path $inexisting_names"


### PR DESCRIPTION
# Description

We attempt (to start - open to discussion) to clean `otp_builds` and `otp_installations` every time `kerl` is run.

Closes #216.
Closes #236.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/kerl/kerl/blob/main/CONTRIBUTING.md)
