### PR TITLE
Fix broken Zsh completion scripts

### DIFF
--- a/zsh_completion/_kerl
+++ b/zsh_completion/_kerl
@@ -110,6 +110,8 @@ case "$words[1]" in
         if [[ "$state" == rels ]]; then
             _kerl_available_releases
             _wanted releases expl 'all releases' compadd -a releases
+        fi
+        ;;
   path)
       _arguments \
           '1: :->installnames' && return 0


### PR DESCRIPTION
# Description

current version of `zsh_completion/_kerl` is invalid. this PR fixes this problem.
