### PR TITLE
`brew` in CI: don't install updates "just because"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,8 @@ jobs:
           if [[ ${{matrix.os}} == macos* ]]; then
             /bin/bash -c "$(curl -fsSL \
               https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-            brew install automake fop wxwidgets fish shellcheck shfmt coreutils
+            HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=yes \
+              brew install automake fop wxwidgets fish shellcheck shfmt coreutils
           else
             sudo sed -i 's/azure\.//' /etc/apt/sources.list # Reduces chance of time-outs
             sudo apt-get update -y


### PR DESCRIPTION
# Description

Showing "Homebrew in CI" some ❤️...

Initial ref: https://github.com/kerl/kerl/pull/497#issuecomment-1858938107.

Implemented as per https://github.com/Homebrew/brew/issues/9285 and https://docs.brew.sh/Manpage.

This reduces the build time and prevents breakage, but only affects CI, not `kerl` itself.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/kerl/kerl/blob/main/CONTRIBUTING.md)
