### PR TITLE
Make Pop!_OS a `kerl`-known Linux distro, for package probing

### DIFF
--- a/kerl
+++ b/kerl
@@ -897,6 +897,9 @@ _KPP_fedora_probe="_rpm"
 _KPP_linuxmint_pkgs=${common_debian_pkgs}
 _KPP_linuxmint_probe="_dpkg"
 
+_KPP_pop_pkgs=${common_debian_pkgs}
+_KPP_pop_probe="_dpkg"
+
 _KPP_rhel_pkgs="${common_ALL_pkgs} openssl-devel ncurses-devel gcc-c++"
 _KPP_rhel_probe="_rpm"
 


### PR DESCRIPTION
# Description

Adding support to PopOS build package validation, closes #504 

Closes #&lt;issue&gt;.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/kerl/kerl/blob/main/CONTRIBUTING.md)
