### PR TITLE
Prevent GitHub CI warnings on "Node.js 16 actions are deprecated"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
           fi
           echo 'KERL_RELEASE_TARGET=debug opt' >> $GITHUB_ENV
       - name: Git checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Update OTP releases
         run: ./kerl update releases
       - name: Choose OTP version

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,15 +7,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Git checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Run ShellCheck and shfmt
-        uses: luizm/action-sh-checker@v0.7.0
+        uses: luizm/action-sh-checker@v0.8.0
         env:
           SHELLCHECK_OPTS: -o all
           SHFMT_OPTS: -i 4 -d
       # uses .markdownlint.yml for configuration
       - name: Run markdownlint
-        uses: DavidAnson/markdownlint-cli2-action@v10
+        uses: DavidAnson/markdownlint-cli2-action@v15
         with:
           globs: |
            *.md


### PR DESCRIPTION
# Description

Solve stuff like e.g. 

```
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/kerl/kerl/blob/main/CONTRIBUTING.md)
