### PR TITLE
fix: `activate` breaks `man` for non-OTP man pages

### DIFF
--- a/kerl
+++ b/kerl
@@ -1314,7 +1314,7 @@ if [ -n "\${MANPATH+x}" ]; then
     if [ -n "\$MANPATH" ]; then
         MANPATH="\${_KERL_MANPATH_REMOVABLE}:\$MANPATH"
     else
-        MANPATH="\${_KERL_MANPATH_REMOVABLE}"
+        MANPATH="\${_KERL_MANPATH_REMOVABLE}:\$(manpath)"
     fi
 else
     MANPATH="\${_KERL_MANPATH_REMOVABLE}"

--- a/kerl
+++ b/kerl
@@ -1456,6 +1456,7 @@ set -x _KERL_MANPATH_REMOVABLE "$directory/lib/erlang/man" "$directory/man"
 set -p _KERL_CLEANUP "set -e _KERL_MANPATH_REMOVABLE;"
 if set -q MANPATH
     if test -n "\$MANPATH"
+        set -xp MANPATH "\$(manpath)"
         set -xp MANPATH \$_KERL_MANPATH_REMOVABLE
     else
         set -x MANPATH \$_KERL_MANPATH_REMOVABLE
@@ -1580,7 +1581,7 @@ unset _KERL_PATH_REMOVABLE
 set _KERL_MANPATH_REMOVABLE = "$directory/lib/erlang/man:$directory/man"
 if ( \$?MANPATH ) then
     if ( "\$MANPATH" == "" ) then
-        setenv MANPATH "\${_KERL_MANPATH_REMOVABLE}"
+        setenv MANPATH "\${_KERL_MANPATH_REMOVABLE}:\`manpath\`"
     else
         setenv MANPATH "\${_KERL_MANPATH_REMOVABLE}:\$MANPATH"
     endif

--- a/tests/activate_test.fish
+++ b/tests/activate_test.fish
@@ -13,7 +13,7 @@ REBAR_PLT_DIR=$DIR\
     if test -n "$MANPATH"
         echo "MANPATH=$DIR/lib/erlang/man:$DIR/man:$MANPATH"
     else
-        echo "MANPATH=$DIR/lib/erlang/man:$DIR/man"
+        echo "MANPATH=$DIR/lib/erlang/man:$DIR/man:$(manpath)"
     end
     set ERLCALLDIR (find "$DIR" -type d -path "*erl_interface*/bin" 2>/dev/null)
     if test -n "$ERLCALLDIR"

--- a/tests/activate_test.sh
+++ b/tests/activate_test.sh
@@ -16,7 +16,7 @@ EOT
     if [ -n "$MANPATH" ]; then
         echo "MANPATH=$DIR/lib/erlang/man:$DIR/man:$MANPATH"
     else
-        echo "MANPATH=$DIR/lib/erlang/man:$DIR/man"
+        echo "MANPATH=$DIR/lib/erlang/man:$DIR/man:$(manpath)"
     fi
     ERLCALLDIR=$(find "$DIR" -type d -path "*erl_interface*/bin" 2>/dev/null)
     if [ -n "$ERLCALLDIR" ]; then

--- a/tests/expected_env.csh
+++ b/tests/expected_env.csh
@@ -11,7 +11,7 @@ if ( $?MANPATH ) then
     if ( $MANPATH != "" ) then
         echo "MANPATH=$DIR/lib/erlang/man:$DIR/man:$MANPATH"
     else
-        echo "MANPATH=$DIR/lib/erlang/man:$DIR/man"
+        echo "MANPATH=$DIR/lib/erlang/man:$DIR/man:`manpath`"
     endif
 else
     echo "MANPATH=$DIR/lib/erlang/man:$DIR/man"


### PR DESCRIPTION
# Description
man by default from what i can tell checks /etc/manpath.config, which then breaks normal usage of man if MANPATH is set without this

fixes #498 

- [x] I have performed a self-review of my changes
  might equally be `manpath -g`, however `manpath`, in my case, preserves user paths such as `$HOME/.local/share/man` 
- [x] I have read and understood the [contributing guidelines](/kerl/kerl/blob/main/CONTRIBUTING.md)
