### PR TITLE
fix: Probe failed for libncurses5-dev

### DIFF
--- a/kerl
+++ b/kerl
@@ -882,7 +882,7 @@ _apk() {
 
 common_ALL_pkgs="gcc make"
 common_ALL_BUILD_BACKEND_git_pkgs="automake autoconf"
-common_debian_pkgs="${common_ALL_pkgs} libssl-dev libncurses5-dev g++"
+common_debian_pkgs="${common_ALL_pkgs} libssl-dev libncurses[^w]*dev g++"
 
 # To add package guessing magic for your Linux distro/package,
 # create a variable named _KPP_<distro>_pkgs where the content


### PR DESCRIPTION
# Description

Relax the probe for libncurses package in Debian-based distros.

Closes #518.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/kerl/kerl/blob/main/CONTRIBUTING.md)

## Local testing

_All commands run with up-to-date apt sources._

<details open><summary>Debian 12 (bookworm) with <code>libncurses5-dev</code> installed</summary>

```sh
$ dpkg-query -l 'libncurses[^w]*dev'
...header...
ii  libncurses-dev:amd64  6.4-4        amd64        developer\'s libraries for ncurses
ii  libncurses5-dev:amd64 6.4-4        amd64        transitional package for libncurses-dev

$ dpkg-query -Wf='${db:Status-abbrev}' "libncurses[^w]*dev"
ii ii

$ ./kerl build 26.2.5
Downloading (from GitHub) Erlang/OTP 26.2.5 to /home/juan/.kerl/archives...
Extracting source code for normal build...
Building (normal) Erlang/OTP 26.2.5 (26.2.5); please wait...
Initializing (build) log file at /home/juan/.kerl/builds/26.2.5/otp_build_26.2.5.log.
^C

$ head -13 /home/juan/.kerl/builds/26.2.5/otp_build_26.2.5.log
*** Sun May  5 03:41:26 PM SAST 2024 - kerl build 26.2.5 ***
Build options:
*
[packages] Found Debian GNU/Linux 12 (bookworm) with ID debian
[packages] Release ID found in /etc/os-release: debian
[packages] Found package declarations for your Linux distro: debian
[packages] Probe success for automake (distro: debian)!
[packages] Probe success for autoconf (distro: debian)!
[packages] Probe success for gcc (distro: debian)!
[packages] Probe success for make (distro: debian)!
[packages] Probe success for libssl-dev (distro: debian)!
[packages] Probe success for libncurses[^w]*dev (distro: debian)!
[packages] Probe success for g++ (distro: debian)!
```

</details> 

<details open><summary>Ubuntu 22.04 (jammy) with <code>libncurses5-dev</code> installed</summary>

```sh
$ dpkg-query -l 'libncurses[^w]*dev'
...header...
ii  libncurses-dev:amd64  6.3-2ubuntu0.1 amd64        developer\'s libraries for ncurses
ii  libncurses5-dev:amd64 6.3-2ubuntu0.1 amd64        transitional package for libncurses-dev

$ dpkg-query -Wf='${db:Status-abbrev}' "libncurses[^w]*dev"
ii ii

$ ./kerl build 26.2.5
Downloading (from GitHub) Erlang/OTP 26.2.5 to /home/juan/.kerl/archives...
Extracting source code for normal build...
Building (normal) Erlang/OTP 26.2.5 (26.2.5); please wait...
Initializing (build) log file at /home/juan/.kerl/builds/26.2.5/otp_build_26.2.5.log.
^C

$ head -13 /home/juan/.kerl/builds/26.2.5/otp_build_26.2.5.log
*** Sun May  5 15:49:00 SAST 2024 - kerl build 26.2.5 ***
Build options:
*
[packages] Found Ubuntu 22.04.4 LTS with ID ubuntu
[packages] Release ID found in /etc/os-release: ubuntu
[packages] Found package declarations for your Linux distro: ubuntu
[packages] Probe success for automake (distro: ubuntu)!
[packages] Probe success for autoconf (distro: ubuntu)!
[packages] Probe success for gcc (distro: ubuntu)!
[packages] Probe success for make (distro: ubuntu)!
[packages] Probe success for libssl-dev (distro: ubuntu)!
[packages] Probe success for libncurses[^w]*dev (distro: ubuntu)!
[packages] Probe success for g++ (distro: ubuntu)!
```

</details>

<details open><summary>Ubuntu 24.04 (noble) with <code>libncurses-dev</code> installed</summary>

```sh
$ dpkg-query -l 'libncurses[^w]*dev'
...header...
ii  libncurses-dev:amd64 6.4+20240113-1ubuntu2 amd64        developer\'s libraries for ncurses
un  libncurses5-dev      <none>                <none>       (no description available)

$ dpkg-query -Wf='${db:Status-abbrev}' "libncurses[^w]*dev" 
ii un

$ ./kerl build 26.2.5       
Downloading (from GitHub) Erlang/OTP 26.2.5 to /home/juan/.kerl/archives...
Extracting source code for normal build...
Building (normal) Erlang/OTP 26.2.5 (26.2.5); please wait...
Initializing (build) log file at /home/juan/.kerl/builds/26.2.5/otp_build_26.2.5.log.
^C

$ head -13 /home/juan/.kerl/builds/26.2.5/otp_build_26.2.5.log 
*** Sun May  5 15:34:23 SAST 2024 - kerl build 26.2.5 ***
Build options:
* 
[packages] Found Ubuntu 24.04 LTS with ID ubuntu
[packages] Release ID found in /etc/os-release: ubuntu
[packages] Found package declarations for your Linux distro: ubuntu
[packages] Probe success for automake (distro: ubuntu)!
[packages] Probe success for autoconf (distro: ubuntu)!
[packages] Probe success for gcc (distro: ubuntu)!
[packages] Probe success for make (distro: ubuntu)!
[packages] Probe success for libssl-dev (distro: ubuntu)!
[packages] Probe success for libncurses[^w]*dev (distro: ubuntu)!
[packages] Probe success for g++ (distro: ubuntu)!
```

</details>