### PR TITLE
feat: standardize on libncurses-dev for dpkg package probing

### DIFF
--- a/kerl
+++ b/kerl
@@ -882,7 +882,7 @@ _apk() {
 
 common_ALL_pkgs="gcc make"
 common_ALL_BUILD_BACKEND_git_pkgs="automake autoconf"
-common_debian_pkgs="${common_ALL_pkgs} libssl-dev libncurses[^w]*dev g++"
+common_debian_pkgs="${common_ALL_pkgs} libssl-dev libncurses-dev g++"
 
 # To add package guessing magic for your Linux distro/package,
 # create a variable named _KPP_<distro>_pkgs where the content


### PR DESCRIPTION
# Description

Improve the error message introduced by relaxing the pkg probe with wildcards.

Closes #522 

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/kerl/kerl/blob/main/CONTRIBUTING.md)


## Improvement

```sh
$ ./kerl build 26.2.5
Extracting source code for normal build...
Building (normal) Erlang/OTP 26.2.5 (26.2.5); please wait...
Initializing (build) log file at /home/juan/.kerl/builds/26.2.5/otp_build_26.2.5.log.
WARNING: [packages] Probe failed for libncurses-dev (distro: ubuntu): probe "dpkg-query -Wf'${db:Status-abbrev}' "libncurses-dev" 2>/dev/null | \grep -q '^i'" returned 1
^C

$ dpkg-query -Wf'${db:Status-abbrev}' libncurses-dev libncurses5-dev 
dpkg-query: no packages found matching libncurses-dev
dpkg-query: no packages found matching libncurses5-dev

$ head -13 /home/juan/.kerl/builds/26.2.5/otp_build_26.2.5.log
*** Mon May  6 11:47:48 SAST 2024 - kerl build 26.2.5 ***
Build options:
* KERL_BUILD_DOCS=yes
[packages] Found Ubuntu 24.04 LTS with ID ubuntu
[packages] Release ID found in /etc/os-release: ubuntu
[packages] Found package declarations for your Linux distro: ubuntu
[packages] Probe success for automake (distro: ubuntu)!
[packages] Probe success for autoconf (distro: ubuntu)!
[packages] Probe success for gcc (distro: ubuntu)!
[packages] Probe success for make (distro: ubuntu)!
[packages] Probe success for libssl-dev (distro: ubuntu)!
[packages] Probe success for g++ (distro: ubuntu)!
[packages] Probe failed for libncurses-dev (distro: ubuntu): probe "dpkg-query -Wf'${db:Status-abbrev}' "libncurses-dev" 2>/dev/null | \grep -q '^i'" returned 1
```