### PR TITLE
On macOS, use OpenSSL 1.1 if Erlang/OTP is pre-25.1, and OpenSSL 3.0 otherwise

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
             /bin/bash -c "$(curl -fsSL \
               https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
             HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=yes \
-              brew install automake wxwidgets fish shellcheck shfmt coreutils
+              brew install automake wxwidgets fish shellcheck shfmt coreutils openssl@3.0
           else
             sudo sed -i 's/azure\.//' /etc/apt/sources.list # Reduces chance of time-outs
             sudo apt-get update -y

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        otp_vsn: [25, 26, 27, master]
+        otp_vsn: ['25.0', '25', '26', '27', 'master']
         os: [ubuntu-22.04, macos-13]
     steps:
       - name: Update env.

--- a/README.md
+++ b/README.md
@@ -312,6 +312,18 @@ a best effort attempt at line numbers. The line numbers may or may not be accura
 
 You can tune `kerl` using the `.kerlrc` file in your `$HOME` directory.
 
+### `kerl` and OpenSSL
+
+If you're running `kerl` on macOS, it will try to guess the OpenSSL
+version to use if none is specified (e.g. via `KERL_CONFIGURE_OPTIONS`' `--with-ssl`).
+
+Since Erlang/OTP 25.1, OpenSSL 3.0 is supported, so the following applies
+
+| Erlang/OTP version | OpenSSL version |
+|-                   |-                |
+| up until 25.1      | 1.1             |
+| after 25.1         | 3.0             |
+
 ## `kerl` options
 
 `kerl` options can be passed either via `.kerlrc` or environment variables, as shown below.

--- a/kerl
+++ b/kerl
@@ -1047,6 +1047,18 @@ uname_r() {
     eval "$(uname_r_label)"
 }
 
+brew_openssl() {
+    # $1: release (or git)
+    otp_major=$(echo "$1" | cut -d. -f1)
+    otp_minor=$(echo "$1" | cut -d. -f2)
+
+    if [ "$otp_major" = 'git' ] || [ "$otp_major" -lt 25 ] || { [ "$otp_major" -eq 25 ] && [ "$otp_minor" -lt 1 ]; }; then
+        brew --prefix openssl@1.1
+    else
+        brew --prefix openssl@3.0
+    fi
+}
+
 _do_build() {
     # $1: release (or git)
     # $2: build name
@@ -1071,7 +1083,7 @@ _do_build() {
         if ! echo "$KERL_CONFIGURE_OPTIONS" | \grep 'with-ssl' >/dev/null 2>&1; then
             whichbrew=$(command -v brew)
             if [ -n "$whichbrew" ] && [ -x "$whichbrew" ]; then
-                brew_prefix=$(brew --prefix openssl@1.1)
+                brew_prefix=$(brew_openssl "$1")
                 if [ -n "$brew_prefix" ] && [ -d "$brew_prefix" ]; then
                     KERL_CONFIGURE_OPTIONS="$KERL_CONFIGURE_OPTIONS "--with-ssl=$brew_prefix
                 fi

--- a/kerl
+++ b/kerl
@@ -1084,8 +1084,12 @@ _do_build() {
             whichbrew=$(command -v brew)
             if [ -n "$whichbrew" ] && [ -x "$whichbrew" ]; then
                 brew_prefix=$(brew_openssl "$1")
+                notice "Attempting to use Homebrew OpenSSL from $brew_prefix..."
                 if [ -n "$brew_prefix" ] && [ -d "$brew_prefix" ]; then
+                    success "... found!"
                     KERL_CONFIGURE_OPTIONS="$KERL_CONFIGURE_OPTIONS "--with-ssl=$brew_prefix
+                else
+                    warn "... you may have to brew the expected version or otherwise use --with-ssl"
                 fi
             fi
         fi


### PR DESCRIPTION
# Description

Since Erlang/OTP 25.1, OpenSSL 3.0 is supported. We can leverage that for the default `build` behaviour, even if you can override it via a config. option.

Closes #472.

There's already a bit, in CI, that tests SSL, via `erl -s crypto -s init stop`.
At the same time, CI's not running for pre 25.1 (**edit**: since 25.0 is inside our chosen 25-27 range, I'm specifically adding 25.0 to CI - even if we decide to remove it before merge), so we can just "trust" that part of the code.

## Further considerations

Here's CI showing it:

* choosing OpenSSL 1.1 for Erlang/OTP 25.0: https://github.com/kerl/kerl/actions/runs/9490113882/job/26152873359?pr=528#step:6:1439
* choosing OpenSSL 3.0 for Erlang/OTP 25.3: https://github.com/kerl/kerl/actions/runs/9490113882/job/26152873809?pr=528#step:6:1485

The main difference between the current implementation and the previous one is that we're "forcing" 3.0 for 25.1+, which would before be forced as 1.1; this means that users that don't have 3.0 installed via brew will get a warning about it.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/kerl/kerl/blob/main/CONTRIBUTING.md)
