### PR TITLE
Bump some of our CI versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         otp_vsn: ['25.0', '25', '26', '27', 'master']
-        os: [ubuntu-22.04, macos-13]
+        os: [ubuntu-24.04, macos-14]
     steps:
       - name: Update env.
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,8 +36,8 @@ jobs:
             sudo apt-get update -y
             sudo apt-get upgrade -y
             sudo apt-get install -y --no-install-recommends \
-              git curl libssl-dev make automake autoconf libncurses5-dev gcc g++ default-jdk \
-              unixodbc-dev libwxgtk3.0-gtk3-dev libwxgtk-webview3.0-gtk3-dev xsltproc \
+              git curl libssl-dev make automake autoconf libncurses-dev gcc g++ default-jdk \
+              unixodbc-dev libwxgtk3.2-dev libwxgtk-webview3.2-dev xsltproc \
               libxml2-utils libsctp-dev lksctp-tools software-properties-common shellcheck \
               shfmt
             sudo apt-add-repository -y ppa:fish-shell/release-3

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   lint:
     name: Lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Git checkout
         uses: actions/checkout@v4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,7 +25,7 @@ jobs:
           SHFMT_OPTS: -i 4 -d
       # uses .markdownlint.yml for configuration
       - name: Run markdownlint
-        uses: DavidAnson/markdownlint-cli2-action@v15
+        uses: DavidAnson/markdownlint-cli2-action@v16
         with:
           globs: |
            *.md


### PR DESCRIPTION
# Description

A few minor version-related updates, to most relevant of which is bumping macOS to 14, to support debugging #529 on OTP 27.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/kerl/kerl/blob/main/CONTRIBUTING.md)

## Further considerations

Packages were updates as per CI results:

* `libncurses5-dev` became `libncurses-dev` (as related to #518 and #522)
* `libwxgtk3.0-gtk3-dev` became `libwxgtk3.2-dev`
* `libwxgtk-webview3.0-gtk3-dev` became `libwxgtk-webview3.2-dev`