### PR TITLE
Fix warning

### DIFF
--- a/kerl
+++ b/kerl
@@ -910,7 +910,7 @@ _KPP_alpine_probe="_apk"
 _KPP_debian_pkgs=${common_debian_pkgs}
 _KPP_debian_probe="_dpkg"
 
-_KPP_fedora_pkgs="${common_ALL_pkgs} openssl-devel ncurses-devel g++"
+_KPP_fedora_pkgs="${common_ALL_pkgs} openssl-devel ncurses-devel gcc-c++"
 _KPP_fedora_probe="_rpm"
 
 _KPP_linuxmint_pkgs=${common_debian_pkgs}


### PR DESCRIPTION
# Description

Fixes the following warning:

```shell
WARNING: [packages] Probe failed for g++ (distro: fedora): probe "rpm -q "g++"" returned 1
```

As it can be seen "g++" is only an alias for "gcc-c++":

```shell
sudo dnf install g++
Last metadata expiration check: 3:38:57 ago on Tue 25 Jun 2024 11:09:27 CEST.
Package gcc-c++-14.1.1-6.fc40.x86_64 is already installed.
Dependencies resolved.
Nothing to do.
Complete!
```

- [x] I have performed a self-review of my changes
- [ ] I have read and understood the [contributing guidelines](/kerl/kerl/blob/main/CONTRIBUTING.md)
   **No**, because link is broken
