### PR TITLE
Have shared code reusable (on the package warning list)

### DIFF
--- a/kerl
+++ b/kerl
@@ -897,6 +897,7 @@ _apk() {
 common_ALL_pkgs="gcc make"
 common_ALL_BUILD_BACKEND_git_pkgs="automake autoconf"
 common_debian_pkgs="${common_ALL_pkgs} libssl-dev libncurses-dev g++"
+common_rhel_pkgs="${common_ALL_pkgs} openssl-devel ncurses-devel gcc-c++"
 
 # To add package guessing magic for your Linux distro/package,
 # create a variable named _KPP_<distro>_pkgs where the content
@@ -910,7 +911,7 @@ _KPP_alpine_probe="_apk"
 _KPP_debian_pkgs=${common_debian_pkgs}
 _KPP_debian_probe="_dpkg"
 
-_KPP_fedora_pkgs="${common_ALL_pkgs} openssl-devel ncurses-devel gcc-c++"
+_KPP_fedora_pkgs=${common_rhel_pkgs}
 _KPP_fedora_probe="_rpm"
 
 _KPP_linuxmint_pkgs=${common_debian_pkgs}
@@ -919,7 +920,7 @@ _KPP_linuxmint_probe="_dpkg"
 _KPP_pop_pkgs=${common_debian_pkgs}
 _KPP_pop_probe="_dpkg"
 
-_KPP_rhel_pkgs="${common_ALL_pkgs} openssl-devel ncurses-devel gcc-c++"
+_KPP_rhel_pkgs=${common_rhel_pkgs}
 _KPP_rhel_probe="_rpm"
 
 _KPP_ubuntu_pkgs=${common_debian_pkgs}


### PR DESCRIPTION
# Description

After I merged #532, I got to thinking that we'd done what I did now, before, but for Debian. So I repeat it for "a little less maintenance".

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/kerl/kerl/blob/main/CONTRIBUTING.md)
