### PR TITLE
Fix kerl path in activate script generation

### DIFF
--- a/kerl
+++ b/kerl
@@ -1334,7 +1334,7 @@ if type kerl_deactivate 2>/dev/null | \grep -qw function; then
     kerl_deactivate
 fi
 
-_KERL=$(command -v kerl)
+_KERL=\$(command -v kerl)
 if [ -n "\$_KERL" ]; then
     _KERL_VERSION=\$(\$_KERL version)
 fi
@@ -1596,7 +1596,7 @@ if ( \$status == 0 ) then
     kerl_deactivate
 endif
 
-set _KERL = $(command -v kerl)
+set _KERL = \$(command -v kerl)
 
 if ( "\$_KERL" != "" ) then
   set _KERL_VERSION = \`\$_KERL version\`

--- a/kerl
+++ b/kerl
@@ -1334,7 +1334,7 @@ if type kerl_deactivate 2>/dev/null | \grep -qw function; then
     kerl_deactivate
 fi
 
-_KERL=\$(command -v kerl)
+_KERL=$(command -v $0)
 if [ -n "\$_KERL" ]; then
     _KERL_VERSION=\$(\$_KERL version)
 fi
@@ -1479,7 +1479,7 @@ if functions -q kerl_deactivate
     kerl_deactivate
 end
 
-set _KERL (command -v kerl)
+set _KERL $(command -v $0)
 
 if test -n "\$_KERL"
   set _KERL_VERSION (\$_KERL version)
@@ -1596,7 +1596,7 @@ if ( \$status == 0 ) then
     kerl_deactivate
 endif
 
-set _KERL = \$(command -v kerl)
+set _KERL = $(command -v $0)
 
 if ( "\$_KERL" != "" ) then
   set _KERL_VERSION = \`\$_KERL version\`


### PR DESCRIPTION
# Description

OTP activate script can point to a non existent kerl.

Example scenarios:
- OTP built on a different path/system
- brew kerl path changed

Closes #&lt;issue&gt;.

- [X] I have performed a self-review of my changes
- [X] I have read and understood the [contributing guidelines](/kerl/kerl/blob/master/CONTRIBUTING.md)
