### PR TITLE
Force `CI` env. variable even if not set by GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ concurrency:
 env:
   ERLC_USE_SERVER: true
   KERL_DEBUG: 'yes'
+  CI: true
 jobs:
   ci:
     name: CI OTP ${{matrix.otp_vsn}}, on ${{matrix.os}}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,6 +11,8 @@ name: Lint
 concurrency:
   group: ${{github.workflow}}-${{github.ref}}
   cancel-in-progress: true
+env:
+  CI: true
 jobs:
   lint:
     name: Lint


### PR DESCRIPTION
# Description

It's a fairly common practice (that the CI environment sets this variable), and we're taking advantage of it in `kerl`'s code, but it seems GitHub Actions might not always honor this "tradition", so we force it. I'm doing this to help in debugging https://github.com/kerl/kerl/pull/535, because I see CI, fail but no message ~, when we should at least see "Colorization disabled as 'tput' (via 'ncurses') seems to be unavailable." issued from `kerl` itself~ (read the code wrong, it's a `-z` there).

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/kerl/kerl/blob/master/CONTRIBUTING.md)
