### PR TITLE
fix: kerl upgrade always upgrading

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,6 +132,8 @@ jobs:
         run: tests/activate_test.fish $_KERL_REL $_KERL_VSN $(./kerl path install_"$_KERL_VSN")
       - name: Test activate/cleanup (csh)
         run: tests/activate_test.csh $_KERL_REL $_KERL_VSN $(./kerl path install_"$_KERL_VSN")
+      - name: Test version parse (sh/bash)
+        run: tests/version_parse_test.sh
       - name: Delete installation
         run: ./kerl delete installation $(./kerl path install_"$_KERL_VSN")
       - name: Delete build

--- a/kerl
+++ b/kerl
@@ -2330,7 +2330,7 @@ version)
         usage_exit "version"
     fi
 
-    tip "$KERL_VERSION"
+    echo "$KERL_VERSION"
     ;;
 build)
     if [ "$2" = 'git' ]; then

--- a/tests/version_parse_test.sh
+++ b/tests/version_parse_test.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+version=$(kerl version)
+if [ -z "$version" ]; then exit 1; fi

--- a/tests/version_parse_test.sh
+++ b/tests/version_parse_test.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-version=$(kerl version)
-if [ -z "$version" ]; then exit 1; fi
+version=$(./kerl version)
+if [ -z "${version}" ]; then exit 1; fi


### PR DESCRIPTION
# Description

I've noticed that calling `kerl upgrade` was always triggering an upgrade because the local version wasn't being properly set. This was introduced in f8c3c7a31490678b88810d75368c7ad7782c604f when the output of `kerl version` (and the other commands) was being sent to stderr, making the assignment `version=$(kerl version)` to be empty.

I'm not sure if changing the `tip` call to an `echo` is the proper solution, but this would also help with external integrations that might also want to parse the kerl version number, and that's what the included test is testing.

Closes #538.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/kerl/kerl/blob/master/CONTRIBUTING.md)
