### PR TITLE
Fix `kerl upgrade` example on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,10 +60,10 @@ Run:
 
 ```console
 $ kerl upgrade
-Local kerl found (/usr/local/bin/kerl) at version 3.0.0.
-Remote kerl found at version 4.2.0.
-Versions are different. Upgrading to 4.2.0...
-kerl 4.2.0 is now available at /usr/local/bin/kerl.
+Local kerl found (/usr/local/bin/kerl) at version 2.6.0.
+Remote kerl found at version 3.0.0.
+Versions are different. Upgrading to 3.0.0...
+kerl 3.0.0 is now available at /usr/local/bin/kerl.
 Updating list of available releases...
 ... done!
 ```

--- a/README.md
+++ b/README.md
@@ -60,10 +60,10 @@ Run:
 
 ```console
 $ kerl upgrade
-Local kerl found (/usr/local/bin/kerl) at version 2.6.0.
-Remote kerl found at version 3.0.0.
-Versions are different. Upgrading to 3.0.0...
-kerl 2.6.0 is now available at /usr/local/bin/kerl.
+Local kerl found (/usr/local/bin/kerl) at version 3.0.0.
+Remote kerl found at version 4.2.0.
+Versions are different. Upgrading to 4.2.0...
+kerl 4.2.0 is now available at /usr/local/bin/kerl.
 Updating list of available releases...
 ... done!
 ```


### PR DESCRIPTION
# Description

The text didn't match the expected (and current) script behaviour, because it was saying that the old version was still available.

Closes #&lt;issue&gt;.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/kerl/kerl/blob/master/CONTRIBUTING.md)
