### PR TITLE
Make bash and zsh completions support custom KERL_BASE_DIR

### DIFF
--- a/bash_completion/kerl
+++ b/bash_completion/kerl
@@ -7,6 +7,10 @@
 # shellcheck disable=SC2312  # Consider invoking this command separately to avoid masking its return value (or use '|| true' to ignore)
 
 _kerl() {
+    if [[ -z ${KERL_BASE_DIR+x} ]]; then
+        KERL_BASE_DIR="$HOME/.kerl"
+    fi
+
     local command cur prev releases builds installations file
 
     command=${COMP_WORDS[1]}
@@ -20,7 +24,7 @@ _kerl() {
     case $command in
     build)
         if [ "$COMP_CWORD" -eq 2 ]; then
-            file="$HOME"/.kerl/otp_releases
+            file="$KERL_BASE_DIR"/otp_releases
             if [ -f "$file" ]; then
                 releases=$(cat "$file")
             fi
@@ -28,7 +32,7 @@ _kerl() {
         fi
         ;;
     install)
-        file="$HOME"/.kerl/otp_builds
+        file="$KERL_BASE_DIR"/otp_builds
         if [ "$COMP_CWORD" -eq 2 ] && [ -f "$file" ]; then
             builds=$(cut -d ',' -f 2 "$file")
             COMPREPLY=($(compgen -W "$builds" -- "$cur"))
@@ -36,7 +40,7 @@ _kerl() {
         ;;
     build-install)
         if [ "$COMP_CWORD" -eq 2 ]; then
-            file="$HOME"/.kerl/otp_releases
+            file="$KERL_BASE_DIR"/otp_releases
             if [ -f "$file" ]; then
                 releases=$(cat "$file")
             fi
@@ -44,7 +48,7 @@ _kerl() {
         fi
         ;;
     deploy)
-        file="$HOME"/.kerl/otp_installations
+        file="$KERL_BASE_DIR"/otp_installations
         if [ "$COMP_CWORD" -eq 3 ] && [ -f "$file" ]; then
             installations=$(cut -d ' ' -f 2 "$file")
             COMPREPLY=($(compgen -W "$installations" -- "$cur"))
@@ -67,13 +71,13 @@ _kerl() {
             COMPREPLY=($(compgen -W 'build installation' -- "$cur"))
         elif [ "$COMP_CWORD" -eq 3 ]; then
             if [ "$prev" == "build" ]; then
-                file="$HOME"/.kerl/otp_builds
+                file="$KERL_BASE_DIR"/otp_builds
                 if [ -f "$file" ]; then
                     builds=$(cut -d ',' -f 2 "$file")
                     COMPREPLY=($(compgen -W "$builds" -- "$cur"))
                 fi
             elif [ "$prev" == "installation" ]; then
-                file="$HOME"/.kerl/otp_installations
+                file="$KERL_BASE_DIR"/otp_installations
                 if [ -f "$file" ]; then
                     installations=$(cut -d ' ' -f 2 "$file")
                     COMPREPLY=($(compgen -W "$installations" -- "$cur"))
@@ -83,7 +87,7 @@ _kerl() {
         ;;
     path)
         if [ "$COMP_CWORD" -eq 2 ]; then
-            file="$HOME"/.kerl/otp_installations
+            file="$KERL_BASE_DIR"/otp_installations
             if [ -f "$file" ]; then
                 installations=$(cut -d ' ' -f 2 "$file" | xargs basename)
                 COMPREPLY=($(compgen -W "$installations" -- "$cur"))
@@ -92,7 +96,7 @@ _kerl() {
         ;;
     cleanup)
         if [ "$COMP_CWORD" -eq 2 ]; then
-            file="$HOME"/.kerl/otp_builds
+            file="$KERL_BASE_DIR"/otp_builds
             if [ -f "$file" ]; then
                 builds=$(cut -d ',' -f 2 "$file")
             fi
@@ -101,19 +105,19 @@ _kerl() {
         ;;
     emit-activate)
         if [ "$COMP_CWORD" -eq 2 ]; then
-            file="$HOME"/.kerl/otp_releases
+            file="$KERL_BASE_DIR"/otp_releases
             if [ -f "$file" ]; then
                 releases=$(cat "$file")
                 COMPREPLY=($(compgen -W "$releases" -- "$cur"))
             fi
         elif [ "$COMP_CWORD" -eq 3 ]; then
-            file="$HOME"/.kerl/otp_builds
+            file="$KERL_BASE_DIR"/otp_builds
             if [ -f "$file" ]; then
                 builds=$(cut -d ',' -f 2 "$file")
                 COMPREPLY=($(compgen -W "$builds" -- "$cur"))
             fi
         elif [ "$COMP_CWORD" -eq 4 ]; then
-            file="$HOME"/.kerl/otp_installations
+            file="$KERL_BASE_DIR"/otp_installations
             if [ -f "$file" ]; then
                 installations=$(cut -d ' ' -f 2 "$file")
                 COMPREPLY=($(compgen -W "$installations" -- "$cur"))

--- a/zsh_completion/_kerl
+++ b/zsh_completion/_kerl
@@ -16,20 +16,24 @@
 #
 # ------------------------------------------------------------------------------
 
+if [[ -z ${KERL_BASE_DIR+x} ]]; then
+    KERL_BASE_DIR="$HOME/.kerl"
+fi
+
 _kerl_otp_releases() {
-    releases=(${(f)"$(_call_program releases cat ~/.kerl/otp_releases 2>/dev/null)"})
+    releases=(${(f)"$(_call_program releases cat $KERL_BASE_DIR/otp_releases 2>/dev/null)"})
 }
 
 _kerl_otp_builds() {
-    builds=(${(f)"$(_call_program builds cat ~/.kerl/otp_builds 2>/dev/null | cut -f 2 -d ",")"})
+    builds=(${(f)"$(_call_program builds cat $KERL_BASE_DIR/otp_builds 2>/dev/null | cut -f 2 -d ",")"})
 }
 
 _kerl_otp_installations_names() {
-    installations=(${(f)"$(_call_program installations cat ~/.kerl/otp_installations 2>/dev/null | cut -f 2 -d " ")"})
+    installations=(${(f)"$(_call_program installations cat $KERL_BASE_DIR/otp_installations 2>/dev/null | cut -f 2 -d " ")"})
 }
 
 _kerl_otp_installations_directories() {
-    installations=(${(f)"$(_call_program installations cat ~/.kerl/otp_installations 2>/dev/null | cut -f 2 -d " " | xargs basename)"})
+    installations=(${(f)"$(_call_program installations cat $KERL_BASE_DIR/otp_installations 2>/dev/null | cut -f 2 -d " " | xargs basename)"})
 }
 
 local -a _1st_arguments


### PR DESCRIPTION
# Description

Add support for custom `KERL_BASE_DIR` in bash and zsh completions.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/kerl/kerl/blob/master/CONTRIBUTING.md)
