### PR TITLE
on OpenBSD we need gtar instead of tar

### DIFF
--- a/kerl
+++ b/kerl
@@ -468,8 +468,14 @@ _curl() {
 
 unpack() {
     # $1: <file> to extract to current directory
-
-    tar -x --no-same-owner --no-same-permissions -zf "$1"
+    case "$KERL_SYSTEM" in
+	OpenBSD)
+    	gtar -x --no-same-owner --no-same-permissions -zf "$1"
+	;;
+	*)
+    	tar -x --no-same-owner --no-same-permissions -zf "$1"
+    	;;
+    esac
 }
 
 get_tarball_releases() {


### PR DESCRIPTION
# Description
On OpenBSD, the `tar` command is different with GNU/Linux's `tar`. So there is a command under `/usr/local/bin` named `gtar`。The `gtar` command can work with well with the given parameters in the `kerl`.
So I add a  `case` statement to test the `KERL_SYSTEM` variable to decide which 'tar' program should be used. 

Closes #&lt;issue&gt;.

- [x] I have read and understood the [contributing guidelines](/kerl/kerl/blob/master/CONTRIBUTING.md)
