### PR TITLE
Fast-track for `kerl version`

### DIFF
--- a/kerl
+++ b/kerl
@@ -79,6 +79,16 @@ usage_exit() {
     exit 1
 }
 
+if [ "$1" = "version" ]; then
+    if [ $# -ne 1 ]; then
+        KERL_COLORIZE=0
+        usage_exit "version"
+    fi
+
+    echo "$KERL_VERSION"
+    exit 0
+fi
+
 error() {
     # $1: log entry
 
@@ -2325,13 +2335,6 @@ fix_otp_builds
 fix_otp_installations
 
 case "$1" in
-version)
-    if [ $# -ne 1 ]; then
-        usage_exit "version"
-    fi
-
-    echo "$KERL_VERSION"
-    ;;
 build)
     if [ "$2" = 'git' ]; then
         if [ $# -ne 5 ]; then


### PR DESCRIPTION
# Description

`kerl version` is used by `activate` script, which in turn is often used by shell prompts. Therefore, any slowness in `kerl version` leads to slower shell prompts / opening of new terminal panes, etc.

Since I had quite a few Erlang builds and installations, and `kerl` iterates through all of them before running any of the commands, I started experiencing slower and slower shell starts.

I went for `KERL_COLORIZE=0` to be able to put the `version` command very near the top of the script.

Before:
```
> time source ~/.kerl/27.2.2/activate.fish

________________________________________________________
Executed in  685.11 millis    fish           external
   usr time   51.66 millis  116.00 micros   51.54 millis
   sys time  158.54 millis  933.00 micros  157.61 millis
```

After:
```
> time source ~/.kerl/27.2.2/activate.fish

________________________________________________________
Executed in   66.20 millis    fish           external
   usr time    5.20 millis    1.56 millis    3.64 millis
   sys time   36.02 millis    1.80 millis   34.22 millis
```

- [x] I have read and understood the [contributing guidelines](/kerl/kerl/blob/master/CONTRIBUTING.md)
