### PR TITLE
Fix MANPATH assignment in kerl script

### DIFF
--- a/kerl
+++ b/kerl
@@ -1404,10 +1404,10 @@ if [ -n "\${MANPATH+x}" ]; then
     if [ -n "\$MANPATH" ]; then
         MANPATH="\${_KERL_MANPATH_REMOVABLE}:\$MANPATH"
     else
-        MANPATH="\${_KERL_MANPATH_REMOVABLE}"
+        MANPATH="\${_KERL_MANPATH_REMOVABLE}:"
     fi
 else
-    MANPATH="\${_KERL_MANPATH_REMOVABLE}"
+    MANPATH="\${_KERL_MANPATH_REMOVABLE}:"
     add_cleanup "
         if [ -z \"\\\$MANPATH\" ]; then
             unset MANPATH


### PR DESCRIPTION
If `MANPATH` is empty, man will look in the standard location `/usr/shar/man/...` In the script `activate`, if `MANPATH` is empty, `MANPATH` is set to `_KERL_MANPATH_REMOVABLE` which sets `MANPATH` to non-empty and that's why `man` wont find the man pages anymore. By adding a single `:` to the end of the `MANPATH` when it is empty will add an empty path and fix the problem.

# Description

Added empty paths to `MANPATH` if `MANPATH` is empty to start with and is replaced by `_KERL_MANPATH_REMOVABLE`

Closes #498.

- [x] I have read and understood the [contributing guidelines](/kerl/kerl/blob/master/CONTRIBUTING.md)
